### PR TITLE
Keep current flashes for one more request

### DIFF
--- a/Controller/Controller.php
+++ b/Controller/Controller.php
@@ -18,6 +18,7 @@ use Symfony\Component\Config\ConfigCache;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\Kernel;
+use Symfony\Component\HttpFoundation\Session\Flash\AutoExpireFlashBag;
 
 /**
  * Controller class.
@@ -66,7 +67,7 @@ class Controller
         } else {
             $session = $request->getSession();
             
-            if (null !== $session && $session->getFlashBag() instanceof \Symfony\Component\HttpFoundation\Session\Flash\AutoExpireFlashBag) {
+            if (null !== $session && $session->getFlashBag() instanceof AutoExpireFlashBag) {
                 // keep current flashes for one more request if using AutoExpireFlashBag
                 $session->getFlashBag()->setAll($session->getFlashBag()->peekAll());
             }


### PR DESCRIPTION
Right now executing routing controller which responds with route json clears flashes for current request.
This pull request fixes this issue the same way it is fixed in symfony web profiler controller:
https://github.com/symfony/symfony/blob/2.0/src/Symfony/Bundle/WebProfilerBundle/Controller/ProfilerController.php#L127
This applies to 2.0, I'm not sure what about new symfony 2.1 because this code looks different in symfony's master branch:
https://github.com/symfony/symfony/blob/master/src/Symfony/Bundle/WebProfilerBundle/Controller/ProfilerController.php#L154
