### PR TITLE
Added how to install using the vendors script.

### DIFF
--- a/Resources/doc/README.markdown
+++ b/Resources/doc/README.markdown
@@ -15,7 +15,7 @@ Or add the following lines in your `deps` file:
 ``` ini
 [FOSJsRoutingBundle]
 	git=git://github.com/FriendsOfSymfony/FOSJsRoutingBundle.git
-    target=/bundles/FOS/JsRoutingBundle
+	target=/bundles/FOS/JsRoutingBundle
 ```
 
 Register the namespace in `app/autoload.php`:


### PR DESCRIPTION
Being new to Symfony, it seems that most bundles include how to use the vendors script in their documentation. Is there an specific reason why this is missing on this bundle?
