### PR TITLE
Removed double `))` in annotation

### DIFF
--- a/Resources/doc/README.markdown
+++ b/Resources/doc/README.markdown
@@ -78,7 +78,7 @@ Or with annotations:
    
     # src/Acme/DemoBundle/Controller/DefaultController.php
     /**
-     * @Route ("/foo/{id}/bar", name="my_route_to_expose", options={"expose"=true}))
+     * @Route ("/foo/{id}/bar", name="my_route_to_expose", options={"expose"=true})
      */
     public function exposedAction($foo)
 


### PR DESCRIPTION
I tried both `)` and `))` and they all work, but it looks like a typo to me. :)
