### PR TITLE
Controller->indexAction(), version_compare bug.

### DIFF
--- a/Controller/Controller.php
+++ b/Controller/Controller.php
@@ -59,7 +59,7 @@ class Controller
      */
     public function indexAction(Request $request, $_format)
     {
-        if (version_compare(Kernel::VERSION, '2.1.0-dev', '<')) {
+        if (version_compare(strtolower(Kernel::VERSION), '2.1.0-dev', '<')) {
             if (null !== $session = $request->getSession()) {
                 // keep current flashes for one more request
                 $session->setFlashes($session->getFlashes());


### PR DESCRIPTION
I don't know what you're trying to achive here but I believe this check works incorrectly, because Kernel::VERSION == 2.1.0-DEV and `var_dump(version_compare('2.1.0-DEV', '2.1.0-dev', '<'));` outputs `bool(true)`.
And currently this bundle always starts session if it weren't started and I don't wont to have session for the anonymous user, can I avoid such behavior? I use Sf 2.1.
