### PR TITLE
Controller. For Sf >= 2.1.0-DEV - avoid to start new session if there is...

### DIFF
--- a/Controller/Controller.php
+++ b/Controller/Controller.php
@@ -66,8 +66,8 @@ class Controller
             }
         } else {
             $session = $request->getSession();
-            
-            if (null !== $session && $session->getFlashBag() instanceof AutoExpireFlashBag) {
+
+            if ($request->hasPreviousSession() && $session->getFlashBag() instanceof AutoExpireFlashBag) {
                 // keep current flashes for one more request if using AutoExpireFlashBag
                 $session->getFlashBag()->setAll($session->getFlashBag()->peekAll());
             }


### PR DESCRIPTION
... no previous one.
`getFlashBag` starts a new session or resumes the previous one. To prevent it from starting a new session I put `hasPreviousSession` check.
