### PR TITLE
the main router:debug command do not accept a compiled route

### DIFF
--- a/Command/RouterDebugExposedCommand.php
+++ b/Command/RouterDebugExposedCommand.php
@@ -57,8 +57,8 @@ EOF
             if (!$route) {
                 throw new \InvalidArgumentException(sprintf('The route "%s" does not exist.', $input->getArgument('name')));
             }
-            $exposedRouteNames = array_keys($extractor->getExposedRoutes());
-            if (in_array($input->getArgument('name'), $exposedRouteNames)) {
+            $exposedRoutes = $extractor->getExposedRoutes();
+            if (isset($exposedRoutes[$input->getArgument('name')]) {
                 $this->outputRoute($output, $input->getArgument('name'));
             } else {
                 throw new \InvalidArgumentException(sprintf('The route "%s" was found, but it is not an exposed route.', $input->getArgument('name')));


### PR DESCRIPTION
with the command

``` bash
./app/console fos:js-routing:debug
```

I get

```
Call to undefined method Symfony\Component\Routing\CompiledRoute::getRequirements()
```

So, after some investigation, I found that the problem is that we are passing a CompiledRoute instead of a Route object, which do not have any getRequirements() method **in the master branch of symfony**

In the 2.0 branch there is the getRequirements method, but I think that this PR should work also on the 2.0 branch, because passing an array of Route objects it's ok in any case.
