### PR TITLE
Escaping html tags for security reasons

### DIFF
--- a/Controller/Controller.php
+++ b/Controller/Controller.php
@@ -90,7 +90,7 @@ class Controller
         $content = file_get_contents((string) $cache);
 
         if ($callback = $request->query->get('callback')) {
-            $content = $callback.'('.$content.');';
+            $content = htmlspecialchars($callback).'('.$content.');';
         }
 
         return new Response($content, 200, array('Content-Type' => $request->getMimeType($_format)));


### PR DESCRIPTION
Repair https://github.com/FriendsOfSymfony/FOSJsRoutingBundle/issues/55
