### PR TITLE
fixed dump command

### DIFF
--- a/Command/DumpCommand.php
+++ b/Command/DumpCommand.php
@@ -51,6 +51,20 @@ class DumpCommand extends ContainerAwareCommand
                 'Set locale to be used with JMSI18nRoutingBundle.',
                 ''
             )
+            ->addOption(
+                    'host',
+                    null,
+                    InputOption::VALUE_OPTIONAL,
+                    'Set host to be used.',
+                    'localhost'
+            )
+            ->addOption(
+                    'scheme',
+                    null,
+                    InputOption::VALUE_OPTIONAL,
+                    'Set URL scheme to be used.',
+                    'http'
+            )
         ;
     }
 
@@ -112,7 +126,9 @@ class DumpCommand extends ContainerAwareCommand
             new RoutesResponse(
                 $baseUrl,
                 $this->getExposedRoutesExtractor()->getRoutes(),
-                $input->getOption('locale')
+                $input->getOption('locale'),
+                $input->getOption('host'),
+                $input->getOption('scheme')
             ),
             'json'
         );


### PR DESCRIPTION
It seems a7b8e7bfbd147d92e0cb75a31a03b8635109641e broke the `dump` command. I've added 2 optional parameters to fix this.
