### PR TITLE
Add missing class properties

### DIFF
--- a/Response/RoutesResponse.php
+++ b/Response/RoutesResponse.php
@@ -16,6 +16,8 @@ class RoutesResponse
     private $baseUrl;
     private $routes;
     private $prefix;
+    private $host;
+    private $scheme;
 
     public function __construct($baseUrl, array $routes, $prefix, $host, $scheme)
     {


### PR DESCRIPTION
These class properties are used in the constructor but are not defined in the class. The additional arguments were added in commit a7b8e7bf
