### PR TITLE
Update README.markdown

### DIFF
--- a/Resources/doc/README.markdown
+++ b/Resources/doc/README.markdown
@@ -45,6 +45,7 @@ $loader->registerNamespaces(array(
     'FOS' => __DIR__.'/../vendor/bundles',
 ));
 ```
+### After downloading (for both Symfony 2.0 or 2.1+):
 
 Register the bundle in `app/AppKernel.php`:
 


### PR DESCRIPTION
In the previous version, the first installation steps for Symfony 2.1+ (editing AppKernel.php, or adding to routing.yml) were not clear.
