### PR TITLE
Add port number to generated absolute URLs

### DIFF
--- a/Extractor/ExposedRoutesExtractor.php
+++ b/Extractor/ExposedRoutesExtractor.php
@@ -128,7 +128,26 @@ class ExposedRoutesExtractor implements ExposedRoutesExtractorInterface
      */
     public function getHost()
     {
-        return $this->router->getContext()->getHost();
+        $requestContext = $this->router->getContext();
+
+        $host = $requestContext->getHost();
+
+        if ($this->usesNonStandardPort()) {
+            $method = sprintf('get%sPort', ucfirst($requestContext->getScheme()));
+            $host .= ':' . $requestContext->$method();
+        }
+
+        return $host;
+    }
+
+    /**
+     * Check whether server is serving this request from a non-standard port.
+     *
+     * @return bool
+     */
+    protected function usesNonStandardPort()
+    {
+        return $this->usesNonStandardHttpPort() || $this->usesNonStandardHttpsPort();
     }
 
     /**
@@ -179,5 +198,25 @@ class ExposedRoutesExtractor implements ExposedRoutesExtractorInterface
         }
 
         return implode($patterns, '|');
+    }
+
+    /**
+     * Checks whether server is serving HTTP over a non-standard port.
+     *
+     * @return bool
+     */
+    private function usesNonStandardHttpPort()
+    {
+        return 'http' === $this->getScheme() && '80' != $this->router->getContext()->getHttpPort();
+    }
+
+    /**
+     * Checks whether server is serving HTTPS over a non-standard port.
+     *
+     * @return bool
+     */
+    private function usesNonStandardHttpsPort()
+    {
+        return 'https' === $this->getScheme() && '443' != $this->router->getContext()->getHttpsPort();
     }
 }

--- a/Extractor/ExposedRoutesExtractorInterface.php
+++ b/Extractor/ExposedRoutesExtractorInterface.php
@@ -42,7 +42,7 @@ interface ExposedRoutesExtractorInterface
     public function getPrefix($locale);
 
     /**
-     * Get the host from RequestContext
+     * Get the host and applicable port from RequestContext
      *
      * @return string
      */

--- a/Tests/Extractor/ExposedRoutesExtractorTest.php
+++ b/Tests/Extractor/ExposedRoutesExtractorTest.php
@@ -13,6 +13,7 @@ namespace FOS\JsRoutingBundle\Tests\Extractor;
 
 use FOS\JsRoutingBundle\Extractor\ExposedRoutesExtractor;
 use FOS\JsRoutingBundle\Extractor\ExtractedRoute;
+use Symfony\Component\Routing\RequestContext;
 use Symfony\Component\Routing\Route;
 use Symfony\Component\HttpKernel\Kernel;
 
@@ -103,6 +104,54 @@ class ExposedRoutesExtractorTest extends \PHPUnit_Framework_TestCase
 
         $extractor = new ExposedRoutesExtractor($router, array(), $this->cacheDir, array());
         $this->assertEquals($this->cacheDir . DIRECTORY_SEPARATOR . 'fosJsRouting' . DIRECTORY_SEPARATOR . 'data.json', $extractor->getCachePath(''));
+    }
+
+    /**
+     * @dataProvider provideTestGetHostOverHttp
+     */
+    public function testGetHostOverHttp($host, $httpPort, $expected)
+    {
+        $requestContext = new RequestContext('/app_dev.php', 'GET', $host, 'http', $httpPort);
+
+        $router = $this->getMock('Symfony\\Component\\Routing\\Router', array(), array(), '', false);
+        $router->expects($this->atLeastOnce())
+            ->method('getContext')
+            ->will($this->returnValue($requestContext));
+
+        $extractor = new ExposedRoutesExtractor($router, array(), $this->cacheDir, array());
+
+        $this->assertEquals($expected, $extractor->getHost());
+    }
+    public function provideTestGetHostOverHttp()
+    {
+        return array(
+            'HTTP Standard' => array('127.0.0.1', 80, '127.0.0.1'),
+            'HTTP Non-Standard' => array('127.0.0.1', 8888, '127.0.0.1:8888'),
+        );
+    }
+
+    /**
+     * @dataProvider provideTestGetHostOverHttps
+     */
+    public function testGetHostOverHttps($host, $httpsPort, $expected)
+    {
+        $requestContext = new RequestContext('/app_dev.php', 'GET', $host, 'https', 80, $httpsPort);
+
+        $router = $this->getMock('Symfony\\Component\\Routing\\Router', array(), array(), '', false);
+        $router->expects($this->atLeastOnce())
+            ->method('getContext')
+            ->will($this->returnValue($requestContext));
+
+        $extractor = new ExposedRoutesExtractor($router, array(), $this->cacheDir, array());
+
+        $this->assertEquals($expected, $extractor->getHost());
+    }
+    public function provideTestGetHostOverHttps()
+    {
+        return array(
+            'HTTPS Standard' => array('127.0.0.1', 443, '127.0.0.1'),
+            'HTTPS Non-Standard' => array('127.0.0.1', 9876, '127.0.0.1:9876'),
+        );
     }
 
     /**


### PR DESCRIPTION
**Step 1:** Host application from a web server running on a specific port (e.g. 127.0.0.1:8888)

**Step 2:** Create a controller, expose its route:

``` php
<?php

namespace Acme\HelloBundle\Controller;

use Sensio\Bundle\FrameworkExtraBundle\Configuration\Route;
use Symfony\Component\HttpFoundation\JsonResponse;

/**
 * @Route("/hello")
 */
class HelloController
{
    /**
     * @Route("/{name}", name="say_hello")
     */
    public function indexAction(Request $request, $name)
    {
        return new JsonResponse(array('name' => $name));
    }
}
```

**Step 3.** Generate a route to its absolute URL:

``` javascript
Routing.generate('say_hello', {'name':'John'}, true);
```

Expected: http://127.0.0.1:8888/app_dev.php/hello/John
Actual: http://127.0.0.1/app_dev.php/hello/John
