### PR TITLE
Only use the config cache if the "prod" environment is active

### DIFF
--- a/Resources/config/controllers.xml
+++ b/Resources/config/controllers.xml
@@ -9,6 +9,7 @@
         <service id="fos_js_routing.controller" class="%fos_js_routing.controller.class%">
             <argument type="service" id="fos_js_routing.serializer" />
             <argument type="service" id="fos_js_routing.extractor" />
+            <argument type="service" id="kernel" />
             <argument>%fos_js_routing.cache_control%</argument>
             <argument>%kernel.debug%</argument>
         </service>


### PR DESCRIPTION
The config cache should not cache the data if the app is not in the prod environment. The problem is, that when developing, the base dir can sometimes change, which currently does not mark the cache as "not fresh".
### Specific use case:

I constantly change between computers when developing websites locally.

If I access the site on my notebook the path is something like: `http://current.local/Project/web/app_dev.php`, if I access it from the network (like a browser testing machine) the URL is `http://192.168.0.1/_current/Project/web/app_dev.php`. The base url change is cached (= the app breaks) without this workaround.
