### PR TITLE
Inject the `locale` parameter automatically

### DIFF
--- a/Controller/Controller.php
+++ b/Controller/Controller.php
@@ -95,7 +95,8 @@ class Controller
             $exposedRoutes,
             $this->exposedRoutesExtractor->getPrefix($request->getLocale()),
             $this->exposedRoutesExtractor->getHost(),
-            $this->exposedRoutesExtractor->getScheme()
+            $this->exposedRoutesExtractor->getScheme(),
+            $request->getLocale()
         );
 
         $content = $this->serializer->serialize($routesResponse, 'json');

--- a/Response/RoutesResponse.php
+++ b/Response/RoutesResponse.php
@@ -20,14 +20,16 @@ class RoutesResponse
     private $prefix;
     private $host;
     private $scheme;
+    private $locale;
 
-    public function __construct($baseUrl, RouteCollection $routes = null, $prefix = null, $host = null, $scheme = null)
+    public function __construct($baseUrl, RouteCollection $routes = null, $prefix = null, $host = null, $scheme = null, $locale = null)
     {
         $this->baseUrl = $baseUrl;
         $this->routes  = $routes ?: new RouteCollection();
         $this->prefix  = $prefix;
         $this->host    = $host;
         $this->scheme  = $scheme;
+        $this->locale  = $locale;
     }
 
     public function getBaseUrl()
@@ -44,6 +46,10 @@ class RoutesResponse
                 $route->getDefaults(),
                 array_fill_keys($compiledRoute->getVariables(), null)
             );
+
+            if (!isset($defaults['_locale']) && in_array('_locale', $compiledRoute->getVariables())) {
+                $defaults['_locale'] = $this->locale;
+            }
 
             $exposedRoutes[$name] = array(
                 'tokens'       => $compiledRoute->getTokens(),

--- a/Tests/Controller/ControllerTest.php
+++ b/Tests/Controller/ControllerTest.php
@@ -51,6 +51,22 @@ class ControllerTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('{"base_url":"","routes":{"literal":{"tokens":[["text","\/homepage"]],"defaults":[],"requirements":[],"hosttokens":[]},"blog":{"tokens":[["variable","\/","[^\/]++","slug"],["text","\/blog-post"]],"defaults":[],"requirements":[],"hosttokens":[["text","localhost"]]}},"prefix":"","host":"","scheme":""}', $response->getContent());
     }
 
+    public function testIndexActionWithLocalizedRoutes()
+    {
+        $routes = new RouteCollection();
+        $routes->add('literal', new Route('/homepage'));
+        $routes->add('blog', new Route('/blog-post/{slug}/{_locale}', array(), array(), array(), 'localhost'));
+
+        $controller = new Controller(
+            $this->getSerializer(),
+            $this->getExtractor($routes)
+        );
+
+        $response = $controller->indexAction($this->getRequest('/'), 'json');
+
+        $this->assertEquals('{"base_url":"","routes":{"literal":{"tokens":[["text","\/homepage"]],"defaults":[],"requirements":[],"hosttokens":[]},"blog":{"tokens":[["variable","\/","[^\/]++","_locale"],["variable","\/","[^\/]++","slug"],["text","\/blog-post"]],"defaults":{"_locale":"en"},"requirements":[],"hosttokens":[["text","localhost"]]}},"prefix":"","host":"","scheme":""}', $response->getContent());
+    }
+
     public function testConfigCache()
     {
         $routes = new RouteCollection();


### PR DESCRIPTION
Injects the _locale parameter when needed by the route and no default value is given. The locale can still be overridden later by the user.
