### PR TITLE
Add note about request context configuration

### DIFF
--- a/Resources/doc/index.md
+++ b/Resources/doc/index.md
@@ -46,6 +46,16 @@ public function registerBundles()
 }
 ```
 
+Configure the Routing Context to know about hostnames when run from the command line:
+``` yml
+# app/config/parameters.yml
+parameters
+    # ...
+    router.request_context.host: example.com
+    # Optionally, if you serve your site through https only
+    # router.request_context.scheme: https
+```
+
 Register the routing definition in `app/config/routing.yml`:
 
 ``` yml


### PR DESCRIPTION
I'm not sure if this is considered the correct approach, but having just run into an issue with http vs https I thought we should probably mention that from the command line, the request context must be configured to know about the host of the site.