### PR TITLE
[DX] This bugfix prevents results override of router:debug command

### DIFF
--- a/Command/RouterDebugExposedCommand.php
+++ b/Command/RouterDebugExposedCommand.php
@@ -54,6 +54,11 @@ EOF
      */
     protected function execute(InputInterface $input, OutputInterface $output)
     {
+        // if called command is not fos:js-routing:debug, return parent logic
+        if ($input->hasArgument('command') && $input->getArgument('command') != $this->getName()) {
+            return parent::execute($input, $output);
+        }
+
         /** @var ExposedRoutesExtractorInterface $extractor */
         $extractor = $this->getContainer()->get('fos_js_routing.extractor');
 


### PR DESCRIPTION
This bugfix prevents results override of router:debug command.

Issue: when you enable FOSJsRoutingBundle in your app, the command `router:debug` starts to return the same result as `fos:js-routing:debug` because  the Symfony's command flow (base class for  `RouterDebugExposedCommand` is  `RouterDebugCommand`).

| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Doc PR | none |
