### PR TITLE
[Feature] DumpCommand --locale-only option

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,18 +10,17 @@ php:
 matrix:
   include:
     - php: 5.5
-      env:
-        - SYMFONY_VERSION='2.3.*'
-        - JMSI18NROUTING_VERSION='dev-master'
+      env: SYMFONY_VERSION='2.3.*'
     - php: 5.5
-      env:
-        - SYMFONY_VERSION='dev-master'
-        - JMSI18NROUTING_VERSION='dev-master'
+      env: SYMFONY_VERSION='dev-master'
+
+env:
+  - JMSI18NROUTING_VERSION='dev-master'
 
 before_script:
   - composer self-update
   - sh -c 'if [ "$SYMFONY_VERSION" != "" ]; then composer require --no-update symfony/symfony=$SYMFONY_VERSION; fi;'
-  - sh -c 'if [ "$JMSI18NROUTING_VERSION" != "" ]; then composer require --no-update jms/i18n-routing-bundle=$JMSI18NROUTING_VERSION; fi;'
+  - composer require --no-update jms/i18n-routing-bundle=$JMSI18NROUTING_VERSION
   - composer install --prefer-source
 
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,13 +10,18 @@ php:
 matrix:
   include:
     - php: 5.5
-      env: SYMFONY_VERSION='2.3.*'
+      env:
+        - SYMFONY_VERSION='2.3.*'
+        - JMSI18NROUTING_VERSION='dev-master'
     - php: 5.5
-      env: SYMFONY_VERSION='dev-master'
+      env:
+        - SYMFONY_VERSION='dev-master'
+        - JMSI18NROUTING_VERSION='dev-master'
 
 before_script:
   - composer self-update
   - sh -c 'if [ "$SYMFONY_VERSION" != "" ]; then composer require --no-update symfony/symfony=$SYMFONY_VERSION; fi;'
+  - sh -c 'if [ "JMSI18NROUTING_VERSION" != "" ]; then composer require --no-update jms/i18n-routing-bundle=$JMSI18NROUTING_VERSION; fi;'
   - composer install --prefer-source
 
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,7 @@ matrix:
 before_script:
   - composer self-update
   - sh -c 'if [ "$SYMFONY_VERSION" != "" ]; then composer require --no-update symfony/symfony=$SYMFONY_VERSION; fi;'
-  - sh -c 'if [ "JMSI18NROUTING_VERSION" != "" ]; then composer require --no-update jms/i18n-routing-bundle=$JMSI18NROUTING_VERSION; fi;'
+  - sh -c 'if [ "$JMSI18NROUTING_VERSION" != "" ]; then composer require --no-update jms/i18n-routing-bundle=$JMSI18NROUTING_VERSION; fi;'
   - composer install --prefer-source
 
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,13 +14,10 @@ matrix:
     - php: 5.5
       env: SYMFONY_VERSION='dev-master'
 
-env:
-  - JMSI18NROUTING_VERSION='dev-master'
-
 before_script:
   - composer self-update
   - sh -c 'if [ "$SYMFONY_VERSION" != "" ]; then composer require --no-update symfony/symfony=$SYMFONY_VERSION; fi;'
-  - composer require --no-update jms/i18n-routing-bundle=$JMSI18NROUTING_VERSION
+  - composer require --no-update jms/i18n-routing-bundle='dev-master'
   - composer install --prefer-source
 
 script:

--- a/Command/DumpCommand.php
+++ b/Command/DumpCommand.php
@@ -82,14 +82,15 @@ class DumpCommand extends ContainerAwareCommand
             throw new \RuntimeException('You must provide a locale to use with --locale-only.');
         }
 
+        $targetPathLocale = '';
         if ($localeOnly) {
-            $localeOnly = sprintf('.%s', $input->getOption('locale'));
+            $targetPathLocale = sprintf('.%s', $input->getOption('locale'));
         }
 
         $this->targetPath = $input->getOption('target') ?:
             sprintf('%s/../web/js/fos_js_routes%s.js',
                 $this->getContainer()->getParameter('kernel.root_dir'),
-                $localeOnly
+                $targetPathLocale
             );
 
         $this->extractor = $this->getContainer()->get('fos_js_routing.extractor');

--- a/Command/DumpCommand.php
+++ b/Command/DumpCommand.php
@@ -64,6 +64,12 @@ class DumpCommand extends ContainerAwareCommand
                 'Set locale to be used with JMSI18nRoutingBundle.',
                 ''
             )
+            ->addOption(
+                'locale-only',
+                null,
+                InputOption::VALUE_NONE,
+                'Set locale only to be used with JMSI18nRoutingBundle. The option --locale must be set.'
+            )
         ;
     }
 
@@ -71,8 +77,20 @@ class DumpCommand extends ContainerAwareCommand
     {
         parent::initialize($input, $output);
 
+        $localeOnly = $input->getOption('locale-only');
+        if (true === $localeOnly && !$input->getOption('locale')) {
+            throw new \RuntimeException('You must provide a locale to use with --locale-only.');
+        }
+
+        if ($localeOnly) {
+            $localeOnly = sprintf('.%s', $input->getOption('locale'));
+        }
+
         $this->targetPath = $input->getOption('target') ?:
-            sprintf('%s/../web/js/fos_js_routes.js', $this->getContainer()->getParameter('kernel.root_dir'));
+            sprintf('%s/../web/js/fos_js_routes%s.js',
+                $this->getContainer()->getParameter('kernel.root_dir'),
+                $localeOnly
+            );
 
         $this->extractor = $this->getContainer()->get('fos_js_routing.extractor');
         $this->serializer = $this->getContainer()->get('fos_js_routing.serializer');
@@ -108,13 +126,17 @@ class DumpCommand extends ContainerAwareCommand
             $this->extractor->getBaseUrl()
         ;
 
+        $localeOnly = $input->getOption('locale-only');
+
         $content = $this->serializer->serialize(
             new RoutesResponse(
                 $baseUrl,
                 $this->extractor->getRoutes(),
-                $input->getOption('locale'),
+                $localeOnly ? '' : $input->getOption('locale'),
                 $this->extractor->getHost(),
-                $this->extractor->getScheme()
+                $this->extractor->getScheme(),
+                $localeOnly ? $input->getOption('locale') : null,
+                $localeOnly
             ),
             'json'
         );

--- a/Response/RoutesResponse.php
+++ b/Response/RoutesResponse.php
@@ -54,7 +54,7 @@ class RoutesResponse
                 $defaults['_locale'] = $this->locale;
             }
 
-            // Removes all the pefix if the route is I18n
+            // Check if the route is I18n
             if (true === $this->localeOnly && false !== ($pos = mb_strpos($name, I18nLoader::ROUTING_PREFIX))) {
                 // Check if the current route is valid to expose with the locale
                 $i18nLocales = $route->getOption('i18n_locales');
@@ -67,6 +67,7 @@ class RoutesResponse
                     continue;
                 }
 
+                // Removes all the pefix
                 $name = substr($name, $pos + strlen(I18nLoader::ROUTING_PREFIX));
             }
 

--- a/Response/RoutesResponse.php
+++ b/Response/RoutesResponse.php
@@ -65,7 +65,8 @@ class RoutesResponse
                     }
 
                     // Remove I18n prefix
-                    $name = str_replace(sprintf('%s%s', $this->locale, I18nLoader::ROUTING_PREFIX), '', $name);
+                    $pattern = sprintf('/%s%s/', $this->locale, I18nLoader::ROUTING_PREFIX);
+                    $name = preg_replace($pattern, '', $name, 1);
                 }
             }
 

--- a/Response/RoutesResponse.php
+++ b/Response/RoutesResponse.php
@@ -12,6 +12,7 @@
 namespace FOS\JsRoutingBundle\Response;
 
 use Symfony\Component\Routing\RouteCollection;
+use JMS\I18nRoutingBundle\Router\I18nLoader;
 
 class RoutesResponse
 {
@@ -21,15 +22,17 @@ class RoutesResponse
     private $host;
     private $scheme;
     private $locale;
+    private $localeOnly;
 
-    public function __construct($baseUrl, RouteCollection $routes = null, $prefix = null, $host = null, $scheme = null, $locale = null)
+    public function __construct($baseUrl, RouteCollection $routes = null, $prefix = null, $host = null, $scheme = null, $locale = null, $localeOnly = false)
     {
-        $this->baseUrl = $baseUrl;
-        $this->routes  = $routes ?: new RouteCollection();
-        $this->prefix  = $prefix;
-        $this->host    = $host;
-        $this->scheme  = $scheme;
-        $this->locale  = $locale;
+        $this->baseUrl    = $baseUrl;
+        $this->routes     = $routes ?: new RouteCollection();
+        $this->prefix     = $prefix;
+        $this->host       = $host;
+        $this->scheme     = $scheme;
+        $this->locale     = $locale;
+        $this->localeOnly = $localeOnly;
     }
 
     public function getBaseUrl()
@@ -49,6 +52,21 @@ class RoutesResponse
 
             if (!isset($defaults['_locale']) && in_array('_locale', $compiledRoute->getVariables())) {
                 $defaults['_locale'] = $this->locale;
+            }
+
+            if (true === $this->localeOnly) {
+                $options = $route->getOptions();
+                if ((isset($options['i18n']) && true === $options['i18n']) ||
+                        (isset($options['i18n_prefix']) && $options['i18n_prefix'])) {
+
+                    $locale = $route->getDefault('_locale');
+                    if ($locale !== $this->locale) {
+                        continue;
+                    }
+
+                    // Remove I18n prefix
+                    $name = str_replace(sprintf('%s%s', $this->locale, I18nLoader::ROUTING_PREFIX), '', $name);
+                }
             }
 
             $exposedRoutes[$name] = array(

--- a/Response/RoutesResponse.php
+++ b/Response/RoutesResponse.php
@@ -54,20 +54,20 @@ class RoutesResponse
                 $defaults['_locale'] = $this->locale;
             }
 
-            if (true === $this->localeOnly) {
-                $options = $route->getOptions();
-                if ((isset($options['i18n']) && true === $options['i18n']) ||
-                        (isset($options['i18n_prefix']) && $options['i18n_prefix'])) {
-
-                    $locale = $route->getDefault('_locale');
-                    if ($locale !== $this->locale) {
-                        continue;
-                    }
-
-                    // Remove I18n prefix
-                    $pattern = sprintf('/%s%s/', $this->locale, I18nLoader::ROUTING_PREFIX);
-                    $name = preg_replace($pattern, '', $name, 1);
+            // Removes all the pefix if the route is I18n
+            if (true === $this->localeOnly && false !== ($pos = mb_strpos($name, I18nLoader::ROUTING_PREFIX))) {
+                // Check if the current route is valid to expose with the locale
+                $i18nLocales = $route->getOption('i18n_locales');
+                if ($i18nLocales && !in_array($this->locale, $i18nLocales)) {
+                    continue;
                 }
+
+                $locale = $route->getDefault('_locale');
+                if ($locale !== $this->locale) {
+                    continue;
+                }
+
+                $name = substr($name, $pos + strlen(I18nLoader::ROUTING_PREFIX));
             }
 
             $exposedRoutes[$name] = array(

--- a/Tests/Command/DumpCommandTest.php
+++ b/Tests/Command/DumpCommandTest.php
@@ -12,7 +12,21 @@
 namespace FOS\JsRoutingBundle\Tests\Command;
 
 use FOS\JsRoutingBundle\Command\DumpCommand;
+use FOS\JsRoutingBundle\Extractor\ExposedRoutesExtractor;
+use JMS\I18nRoutingBundle\Router\I18nLoader;
+use JMS\I18nRoutingBundle\Router\I18nRouter;
+use JMS\I18nRoutingBundle\Router\DefaultRouteExclusionStrategy;
+use JMS\I18nRoutingBundle\Router\DefaultPatternGenerationStrategy;
 use Symfony\Component\Console\Tester\CommandTester;
+use Symfony\Component\DependencyInjection\Container;
+use Symfony\Component\Routing\Loader\YamlFileLoader;
+use Symfony\Component\Translation\Loader\YamlFileLoader as TranslationLoader;
+use Symfony\Component\Config\FileLocator;
+use Symfony\Component\Translation\Translator;
+use Symfony\Component\Translation\MessageSelector;
+use Symfony\Component\Serializer\Serializer;
+use Symfony\Component\Serializer\Normalizer\GetSetMethodNormalizer;
+use Symfony\Component\Serializer\Encoder\JsonEncoder;
 
 class DumpCommandTest extends \PHPUnit_Framework_TestCase
 {
@@ -134,5 +148,81 @@ class DumpCommandTest extends \PHPUnit_Framework_TestCase
 
         $tester = new CommandTester($command);
         $tester->execute(array('--target' => '/tmp'));
+    }
+
+    /**
+     * @dataProvider getLocaleOnlyData
+     */
+    public function testExecuteWithLocaleOnly($locale, $expected)
+    {
+        $container = new Container();
+        $router = $this->getRouter($container);
+
+        $tmpDir = sys_get_temp_dir();
+        $container->setParameter('kernel.root_dir', $tmpDir);
+
+        $container->set('fos_js_routing.extractor', new ExposedRoutesExtractor($router, array(), null));
+        $container->set('fos_js_routing.serializer', new Serializer(array(new GetSetMethodNormalizer()), array(new JsonEncoder())));
+
+        $command = new DumpCommand();
+        $command->setContainer($container);
+
+        $tester = new CommandTester($command);
+        $tester->execute(array('--locale' => $locale, '--locale-only' => true));
+
+        $filename = sprintf('%s/../web/js/fos_js_routes%s.js', $tmpDir, sprintf('.%s', $locale));
+        $this->assertEquals($expected, @file_get_contents($filename));
+    }
+
+    public function getLocaleOnlyData()
+    {
+        return array(
+            array(
+                'en',
+                'fos.Router.setData({"baseUrl":"","routes":{"homepage":{"tokens":[["text","\/homepage-english"]],"defaults":[],"requirements":[],"hosttokens":[]},"foo":{"tokens":[["text","\/foo-en"]],"defaults":[],"requirements":[],"hosttokens":[]},"bar":{"tokens":[["text","\/bar-en"]],"defaults":[],"requirements":[],"hosttokens":[]},"untranslated_route":{"tokens":[["text","\/not-translated"]],"defaults":[],"requirements":[],"hosttokens":[]},"english_only":{"tokens":[["text","\/english-only"]],"defaults":[],"requirements":[],"hosttokens":[]},"non_i18n_route":{"tokens":[["text","\/non-i18n-route"]],"defaults":[],"requirements":[],"hosttokens":[]}},"prefix":"","host":"localhost","scheme":"http"});'
+            ),
+            array(
+                'es',
+                'fos.Router.setData({"baseUrl":"","routes":{"homepage":{"tokens":[["text","\/homepage-spanish"]],"defaults":[],"requirements":[],"hosttokens":[]},"foo":{"tokens":[["text","\/foo-es"]],"defaults":[],"requirements":[],"hosttokens":[]},"bar":{"tokens":[["text","\/bar-es"]],"defaults":[],"requirements":[],"hosttokens":[]},"untranslated_route":{"tokens":[["text","\/not-translated"]],"defaults":[],"requirements":[],"hosttokens":[]},"spanish_only":{"tokens":[["text","\/spanish-only"]],"defaults":[],"requirements":[],"hosttokens":[]},"non_i18n_route":{"tokens":[["text","\/non-i18n-route"]],"defaults":[],"requirements":[],"hosttokens":[]}},"prefix":"","host":"localhost","scheme":"http"});'
+            ),
+        );
+    }
+
+    /**
+     * @expectedException \RuntimeException
+     * @expectedExceptionMessage You must provide a locale to use with --locale-only.
+     */
+    public function testExecuteWithLocaleOnlyWithoutLocale()
+    {
+        $command = new DumpCommand();
+        $command->setContainer($this->container);
+
+        $tester = new CommandTester($command);
+        $tester->execute(array('--locale-only' => true));
+    }
+
+    private function getRouter($container, $config = 'routing.yml', $translator = null, $localeResolver = null)
+    {
+        $container->set('routing.loader', new YamlFileLoader(new FileLocator(__DIR__.'/Fixture')));
+
+        if (null === $translator) {
+            $translator = new Translator('en', new MessageSelector());
+            $translator->setFallbackLocale('en');
+            $translator->addLoader('yml', new TranslationLoader());
+            $translator->addResource('yml', __DIR__.'/Fixture/routes.en.yml', 'en', 'routes');
+            $translator->addResource('yml', __DIR__.'/Fixture/routes.es.yml', 'es', 'routes');
+        }
+
+        $container->set('i18n_loader', new I18nLoader(new DefaultRouteExclusionStrategy(), new DefaultPatternGenerationStrategy('custom', $translator, array('en', 'es'), sys_get_temp_dir())));
+
+        $router = new I18nRouter($container, $config);
+        $router->setI18nLoaderId('i18n_loader');
+        $router->setDefaultLocale('en');
+
+        if (null !== $localeResolver) {
+            $router->setLocaleResolver($localeResolver);
+        }
+
+        return $router;
     }
 }

--- a/Tests/Command/DumpCommandTest.php
+++ b/Tests/Command/DumpCommandTest.php
@@ -158,20 +158,18 @@ class DumpCommandTest extends \PHPUnit_Framework_TestCase
         $container = new Container();
         $router = $this->getRouter($container);
 
-        $tmpDir = sys_get_temp_dir();
-        $container->setParameter('kernel.root_dir', $tmpDir);
-
         $container->set('fos_js_routing.extractor', new ExposedRoutesExtractor($router, array(), null));
         $container->set('fos_js_routing.serializer', new Serializer(array(new GetSetMethodNormalizer()), array(new JsonEncoder())));
+
+        $target = sprintf('%s/FOSJsRoutingBundle/fos_js_routes%s.js', sys_get_temp_dir(), sprintf('.%s', $locale));
 
         $command = new DumpCommand();
         $command->setContainer($container);
 
         $tester = new CommandTester($command);
-        $tester->execute(array('--locale' => $locale, '--locale-only' => true));
+        $tester->execute(array('--target' => $target, '--locale' => $locale, '--locale-only' => true));
 
-        $filename = sprintf('%s/../web/js/fos_js_routes%s.js', $tmpDir, sprintf('.%s', $locale));
-        $this->assertEquals($expected, @file_get_contents($filename));
+        $this->assertEquals($expected, @file_get_contents($target));
     }
 
     public function getLocaleOnlyData()

--- a/Tests/Command/Fixture/routes.en.yml
+++ b/Tests/Command/Fixture/routes.en.yml
@@ -1,0 +1,3 @@
+homepage: /homepage-english
+foo: /foo-en
+bar: /bar-en

--- a/Tests/Command/Fixture/routes.es.yml
+++ b/Tests/Command/Fixture/routes.es.yml
@@ -1,0 +1,3 @@
+homepage: /homepage-spanish
+foo: /foo-es
+bar: /bar-es

--- a/Tests/Command/Fixture/routing.yml
+++ b/Tests/Command/Fixture/routing.yml
@@ -1,0 +1,30 @@
+homepage:
+    pattern: /
+    defaults: { _controller: homepage }
+    options:  { expose: true }
+
+foo:
+    pattern: /foo
+    defaults: { _controller: foo }
+    options:  { expose: true }
+
+bar:
+    pattern: /bar
+    defaults: { _controller: bar }
+    options:  { expose: true }
+
+untranslated_route:
+    pattern: /not-translated
+    options:  { expose: true }
+
+english_only:
+    pattern: /english-only
+    options: { i18n_locales: ['en'], expose: true }
+
+spanish_only:
+    pattern: /spanish-only
+    options: { i18n_locales: ['es'], expose: true }
+
+non_i18n_route:
+    pattern: /non-i18n-route
+    options: { i18n: false, expose: true }


### PR DESCRIPTION
Hi.
**Important**: no testing. If you think it is a good feature to implement I can make it.

I create a new option in the DumpCommand "--locale-only", which only generates the I18n routes associated to the locale passed in "--locale", and the the not I18n routes.

This can be a scenario:

default_locale: 'en'
locales: ['en', 'es']
routes:
1 - acme/no-translation'
2 - en => 'acme/foo' | es => 'es/acme/foo'
3 - en => 'acme/bar' | es => 'es/acme/bar'

```
php bin/console fos:js-routing:dump --locale=en --locale-only
```
Will dump: acme/no-translation', 'acme/foo', 'acme/bar'

```
php bin/console fos:js-routing:dump --locale=es --locale-only
```
Will dump: acme/no-translation', 'es/acme/foo', 'es/acme/bar'