### PR TITLE
Update index.md

### DIFF
--- a/Resources/doc/index.md
+++ b/Resources/doc/index.md
@@ -20,13 +20,8 @@ Installation
 Require [`friendsofsymfony/jsrouting-bundle`](https://packagist.org/packages/friendsofsymfony/jsrouting-bundle)
 into your `composer.json` file:
 
-
-``` json
-{
-    "require": {
-        "friendsofsymfony/jsrouting-bundle": "@stable"
-    }
-}
+```sh
+composer require friendsofsymfony/jsrouting-bundle
 ```
 
 **Protip:** you should browse the


### PR DESCRIPTION
Updated installation instructions via composer to use the `composer require` command without specifying a version.
This is the new recommended way of providing this information and it leads to composer picking the proper version constraint (i.e ~1.2), updating the `composer.json` and running install, all in one command.
