### PR TITLE
Patch release for a 1.5.4 release

### DIFF
--- a/Command/RouterDebugExposedCommand.php
+++ b/Command/RouterDebugExposedCommand.php
@@ -34,6 +34,7 @@ class RouterDebugExposedCommand extends RouterDebugCommand
 
         $this
             ->setName('fos:js-routing:debug')
+            ->setAliases(array()) // reset the aliases used by the parent command in Symfony 2.6+
             ->setDescription('Displays currently exposed routes for an application')
             ->setHelp(<<<EOF
 The <info>fos:js-routing:debug</info> command displays an application's routes which will be available via JavaScript.

--- a/Resources/js/router_test.html
+++ b/Resources/js/router_test.html
@@ -5,7 +5,7 @@
         <title>Router Test</title>
     </head>
     <body>
-        <script language="javascript" type="text/javascript" src="http://closure-library.googlecode.com/svn/trunk/closure/goog/base.js"></script>
+        <script language="javascript" type="text/javascript" src="https://rawgit.com/google/closure-library/master/closure/goog/base.js"></script>
         <script language="javascript" type="text/javascript" src="router.js"></script>
         <script language="javascript" type="text/javascript" src="router.test.js"></script>
     </body>


### PR DESCRIPTION
This fixes #180.

From the commits since the last tag to master (https://github.com/FriendsOfSymfony/FOSJsRoutingBundle/compare/1.5.3...master), I only identified 2 things that could be considered bug fixes (and one fixes a test, so it's not important).

@stof The only commit that *maybe* should also be included is sha: cd5229ba6b1fc584fc2c685d355a94ecb01e38d6. If that is indeed a bug fix, let me know and I'll patch it onto here.

The idea is that this will let us tag a new 1.5.4, which (primarily) has a bug fix for Symfony 2.6.

Thanks!