### PR TITLE
Fix deprecated routing configuration

### DIFF
--- a/Resources/config/routing/routing.xml
+++ b/Resources/config/routing/routing.xml
@@ -3,7 +3,7 @@
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xsi:schemaLocation="http://symfony.com/schema/routing http://symfony.com/schema/routing/routing-1.0.xsd">
 
-    <route id="fos_js_routing_js" pattern="/js/routing.{_format}">
+    <route id="fos_js_routing_js" path="/js/routing.{_format}">
         <default key="_controller">fos_js_routing.controller:indexAction</default>
         <default key="_format">js</default>
         <requirement key="_format">js|json</requirement>


### PR DESCRIPTION
This PR fix deprecated routing config throwing related errors:

> The "pattern" is deprecated since version 2.2 and will be removed in 3.0. Use the "path" option in the route definition instead.
