### PR TITLE
Fix ConfigCache deprecation with Symfony 2.7

### DIFF
--- a/Controller/Controller.php
+++ b/Controller/Controller.php
@@ -82,7 +82,8 @@ class Controller
             $serializedRoutes = $this->serializer->serialize($exposedRoutes, 'json');
             $cache->write($serializedRoutes, $this->exposedRoutesExtractor->getResources());
         } else {
-            $serializedRoutes = file_get_contents((string) $cache);
+            $path = method_exists($cache, 'getPath') ? $cache->getPath() : (string) $cache;
+            $serializedRoutes = file_get_contents($path);
             $exposedRoutes    = $this->serializer->deserialize(
                 $serializedRoutes,
                 'Symfony\Component\Routing\RouteCollection',


### PR DESCRIPTION
According to Symfony 2.7

> ConfigCache::__toString() is deprecated since version 2.7 and will be removed in 3.0. Use the getPath() method instead.

So I updated the call in the controller