### PR TITLE
Protection against rosetta flash attacks

### DIFF
--- a/Controller/Controller.php
+++ b/Controller/Controller.php
@@ -108,7 +108,7 @@ class Controller
                 throw new HttpException(400, 'Invalid JSONP callback value');
             }
 
-            $content = $callback.'('.$content.');';
+            $content = '/**/' . $callback . '(' . $content . ');';
         }
 
         $response = new Response($content, 200, array('Content-Type' => $request->getMimeType($_format)));

--- a/Tests/Controller/ControllerTest.php
+++ b/Tests/Controller/ControllerTest.php
@@ -94,7 +94,7 @@ class ControllerTest extends \PHPUnit_Framework_TestCase
         $response   = $controller->indexAction($this->getRequest('/', 'GET', array('callback' => $callback)), 'json');
 
         $this->assertEquals(
-            sprintf('%s({"base_url":"","routes":[],"prefix":"","host":"","scheme":""});', $callback),
+            sprintf('/**/%s({"base_url":"","routes":[],"prefix":"","host":"","scheme":""});', $callback),
             $response->getContent()
         );
     }


### PR DESCRIPTION
This is a rather important security patch. It adds a comment at the beginning of jsonp responses. Instead of 

```javascript
fos.Router.setData(...)
```

you get

```javascript
/**/fos.Router.setData(...)
```