### PR TITLE
Adding a javascript comment to the beginning of the JSONP endpoint re…

### DIFF
--- a/Controller/Controller.php
+++ b/Controller/Controller.php
@@ -108,7 +108,7 @@ class Controller
                 throw new HttpException(400, 'Invalid JSONP callback value');
             }
 
-            $content = $callback.'('.$content.');';
+            $content = '/**/'.$callback.'('.$content.');';
         }
 
         $response = new Response($content, 200, array('Content-Type' => $request->getMimeType($_format)));

--- a/Tests/Controller/ControllerTest.php
+++ b/Tests/Controller/ControllerTest.php
@@ -94,7 +94,7 @@ class ControllerTest extends \PHPUnit_Framework_TestCase
         $response   = $controller->indexAction($this->getRequest('/', 'GET', array('callback' => $callback)), 'json');
 
         $this->assertEquals(
-            sprintf('%s({"base_url":"","routes":[],"prefix":"","host":"","scheme":""});', $callback),
+	    sprintf('%s({"base_url":"","routes":[],"prefix":"","host":"","scheme":""});', '/**/'.$callback),
             $response->getContent()
         );
     }


### PR DESCRIPTION
Adding a javascript comment to the beginning of the JSONP endpoint response to prevent the following vulnerability  http://web.nvd.nist.gov/view/vuln/detail?vulnId=CVE-2014-4671