### PR TITLE
Use the bundle relative path instead dumped one on /web

### DIFF
--- a/Resources/doc/index.md
+++ b/Resources/doc/index.md
@@ -208,7 +208,7 @@ Or inside assetic, do
 
 ```jinja
 {% javascripts filter='?yui_js'
-    'bundles/fosjsrouting/js/router.js'
+    '@FOSJsRoutingBundle/Resources/public/js/router.js'
     'js/fos_js_routes.js'
 %}
     <script src="{{ asset_url }}"></script>


### PR DESCRIPTION
If you use the relative to bundle path you don't need to first dump assets if set use_controller: true in assetic config.