### PR TITLE
Expose routing options to javascript routes

### DIFF
--- a/Command/DumpCommand.php
+++ b/Command/DumpCommand.php
@@ -120,13 +120,19 @@ class DumpCommand extends ContainerAwareCommand
             $params = array();
         }
 
+        $exposeRouteOptions = $this->getContainer()->hasParameter('fos_js_routing.expose_options') ?
+            $this->getContainer()->getParameter('fos_js_routing.expose_options') :
+            false;
+
         $content = $this->serializer->serialize(
             new RoutesResponse(
                 $baseUrl,
                 $this->extractor->getRoutes(),
                 $input->getOption('locale'),
                 $this->extractor->getHost(),
-                $this->extractor->getScheme()
+                $this->extractor->getScheme(),
+                null,
+                $exposeRouteOptions
             ),
             'json',
             $params

--- a/Controller/Controller.php
+++ b/Controller/Controller.php
@@ -48,19 +48,26 @@ class Controller
     protected $debug;
 
     /**
+     * @var boolean
+     */
+    private $exposeRouteOptions;
+    
+    /**
      * Default constructor.
      *
      * @param object                          $serializer             Any object with a serialize($data, $format) method
      * @param ExposedRoutesExtractorInterface $exposedRoutesExtractor The extractor service.
      * @param array                           $cacheControl
      * @param boolean                         $debug
+     * @param boolean                         $exposeRouteOptions
      */
-    public function __construct($serializer, ExposedRoutesExtractorInterface $exposedRoutesExtractor, array $cacheControl = array(), $debug = false)
+    public function __construct($serializer, ExposedRoutesExtractorInterface $exposedRoutesExtractor, array $cacheControl = array(), $debug = false, $exposeRouteOptions = false)
     {
         $this->serializer             = $serializer;
         $this->exposedRoutesExtractor = $exposedRoutesExtractor;
         $this->cacheControlConfig     = new CacheControlConfig($cacheControl);
         $this->debug                  = $debug;
+        $this->exposeRouteOptions     = $exposeRouteOptions;
     }
 
     /**
@@ -97,7 +104,8 @@ class Controller
             $this->exposedRoutesExtractor->getPrefix($request->getLocale()),
             $this->exposedRoutesExtractor->getHost(),
             $this->exposedRoutesExtractor->getScheme(),
-            $request->getLocale()
+            $request->getLocale(),
+            $this->exposeRouteOptions
         );
 
         $content = $this->serializer->serialize($routesResponse, 'json');

--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -57,6 +57,7 @@ class Configuration implements ConfigurationInterface
                         ->end()
                     ->end()
                 ->end()
+                ->booleanNode('expose_options')->defaultFalse()->end()
             ->end();
 
         return $builder;

--- a/DependencyInjection/FOSJsRoutingExtension.php
+++ b/DependencyInjection/FOSJsRoutingExtension.php
@@ -64,5 +64,6 @@ class FOSJsRoutingExtension extends Extension
         }
 
         $container->setParameter('fos_js_routing.cache_control', $config['cache_control']);
+        $container->setParameter('fos_js_routing.expose_options', $config['expose_options']);
     }
 }

--- a/Resources/config/controllers.xml
+++ b/Resources/config/controllers.xml
@@ -11,6 +11,7 @@
             <argument type="service" id="fos_js_routing.extractor" />
             <argument>%fos_js_routing.cache_control%</argument>
             <argument>%kernel.debug%</argument>
+            <argument>%fos_js_routing.expose_options%</argument>
         </service>
     </services>
 </container>

--- a/Resources/doc/index.md
+++ b/Resources/doc/index.md
@@ -184,6 +184,10 @@ Or using annotations:
 public function exposedAction($foo)
 ```
 
+Will result in the options property:
+```JavaScript
+{"base_url":"","routes":{"my_route_to_expose":{"tokens":[["text","\/bar"],["variable","\/","[^\/]++","id"],["text","\/development\/foo"]],"defaults":[],"requirements":[],"hosttokens":[],"options":{"callback":"doStuff","is_single_page":true}}},"prefix":"","host":"localhost","scheme":"http"}
+```
 
 ### Router service
 

--- a/Resources/doc/index.md
+++ b/Resources/doc/index.md
@@ -153,6 +153,38 @@ my_very_secret_route:
         expose: false
 ```
 
+### Expose Route Options to JS
+If you want to expose some options from the routing definition to the JS definitions
+you can set the config parameter:
+```yaml
+fos_js_routing.expose_options: true
+```
+Every option which is defined in the exposed_options option is then added to the generated JS routes.
+
+
+```yaml
+# app/config/routing.yml
+my_route_to_expose:
+    pattern: /foo/{id}/bar
+    defaults: { _controller: HelloBundle:Hello:index }
+    options:
+        expose: true
+        exposed_options: 
+            callback: doStuff
+            is_single_page: true
+```
+
+Or using annotations:
+
+```php
+// src/Acme/DemoBundle/Controller/DefaultController.php
+/**
+ * @Route("/foo/{id}/bar", name="my_route_to_expose", options={"expose"=true, exposed_options={callback="doStuff", is_single_page=true}})
+ */
+public function exposedAction($foo)
+```
+
+
 ### Router service
 
 By default, this bundle exports routes from the default service `router`. You

--- a/Resources/js/router_test.html
+++ b/Resources/js/router_test.html
@@ -5,7 +5,7 @@
         <title>Router Test</title>
     </head>
     <body>
-        <script language="javascript" type="text/javascript" src="https://rawgit.com/google/closure-library/master/closure/goog/base.js"></script>
+        <script language="javascript" type="text/javascript" src="https://cdn.rawgit.com/google/closure-library/master/closure/goog/base.js"></script>
         <script language="javascript" type="text/javascript" src="router.js"></script>
         <script language="javascript" type="text/javascript" src="router.test.js"></script>
     </body>

--- a/Resources/js/router_test.html
+++ b/Resources/js/router_test.html
@@ -5,7 +5,7 @@
         <title>Router Test</title>
     </head>
     <body>
-        <script language="javascript" type="text/javascript" src="https://cdn.rawgit.com/google/closure-library/master/closure/goog/base.js"></script>
+        <script language="javascript" type="text/javascript" src="https://raw.githubusercontent.com/google/closure-library/master/closure/goog/base.js"></script>
         <script language="javascript" type="text/javascript" src="router.js"></script>
         <script language="javascript" type="text/javascript" src="router.test.js"></script>
     </body>

--- a/Response/RoutesResponse.php
+++ b/Response/RoutesResponse.php
@@ -21,15 +21,17 @@ class RoutesResponse
     private $host;
     private $scheme;
     private $locale;
+    private $exposeRouteOptions;
 
-    public function __construct($baseUrl, RouteCollection $routes = null, $prefix = null, $host = null, $scheme = null, $locale = null)
+    public function __construct($baseUrl, RouteCollection $routes = null, $prefix = null, $host = null, $scheme = null, $locale = null, $exposeRouteOptions = false)
     {
-        $this->baseUrl = $baseUrl;
-        $this->routes  = $routes ?: new RouteCollection();
-        $this->prefix  = $prefix;
-        $this->host    = $host;
-        $this->scheme  = $scheme;
-        $this->locale  = $locale;
+        $this->baseUrl            = $baseUrl;
+        $this->routes             = $routes ?: new RouteCollection();
+        $this->prefix             = $prefix;
+        $this->host               = $host;
+        $this->scheme             = $scheme;
+        $this->locale             = $locale;
+        $this->exposeRouteOptions = $exposeRouteOptions;
     }
 
     public function getBaseUrl()
@@ -57,6 +59,11 @@ class RoutesResponse
                 'requirements' => $route->getRequirements(),
                 'hosttokens'   => method_exists($compiledRoute, 'getHostTokens') ? $compiledRoute->getHostTokens() : array(),
             );
+
+            $options = $route->getOptions();
+            if ($this->exposeRouteOptions && !empty($options['exposed_options'])) {
+                $exposedRoutes[$name]['options'] = $options['exposed_options'];
+            }
         }
 
         return $exposedRoutes;

--- a/Tests/Command/DumpCommandTest.php
+++ b/Tests/Command/DumpCommandTest.php
@@ -13,9 +13,13 @@ namespace FOS\JsRoutingBundle\Tests\Command;
 
 use FOS\JsRoutingBundle\Command\DumpCommand;
 use Symfony\Component\Console\Tester\CommandTester;
+use Symfony\Component\DependencyInjection\ContainerInterface;
 
 class DumpCommandTest extends \PHPUnit_Framework_TestCase
 {
+    /**
+     * @var ContainerInterface|\PHPUnit_Framework_MockObject_MockObject
+     */
     protected $container;
     protected $extractor;
     protected $router;
@@ -52,6 +56,18 @@ class DumpCommandTest extends \PHPUnit_Framework_TestCase
             ->method('get')
             ->with('fos_js_routing.serializer')
             ->will($this->returnValue($this->serializer));
+
+        $this->container
+            ->method('hasParameter')
+            ->willReturnMap(array(
+                array('fos_js_routing.request_context_base_url', false),
+                array('fos_js_routing.expose_options', true),
+            ));
+
+        $this->container->expects($this->atLeastOnce())
+            ->method('getParameter')
+            ->with('fos_js_routing.expose_options')
+            ->will($this->returnValue(true));
 
         $command = new DumpCommand();
         $command->setContainer($this->container);

--- a/Tests/Controller/ControllerTest.php
+++ b/Tests/Controller/ControllerTest.php
@@ -67,6 +67,25 @@ class ControllerTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('{"base_url":"","routes":{"literal":{"tokens":[["text","\/homepage"]],"defaults":[],"requirements":[],"hosttokens":[]},"blog":{"tokens":[["variable","\/","[^\/]++","_locale"],["variable","\/","[^\/]++","slug"],["text","\/blog-post"]],"defaults":{"_locale":"en"},"requirements":[],"hosttokens":[["text","localhost"]]}},"prefix":"","host":"","scheme":""}', $response->getContent());
     }
 
+    public function testIndexActionWithExposedOptions()
+    {
+        $routes = new RouteCollection();
+        $routes->add('literal', new Route('/homepage'));
+        $routes->add('blog', new Route('/blog-post/{slug}', array(), array(), array('exposed_options' => array('whatever' => false, 'angular_controller' => 'test')), 'localhost'));
+
+        $controller = new Controller(
+            $this->getSerializer(),
+            $this->getExtractor($routes),
+            array(),
+            false,
+            true
+        );
+
+        $response = $controller->indexAction($this->getRequest('/'), 'json');
+
+        $this->assertEquals('{"base_url":"","routes":{"literal":{"tokens":[["text","\/homepage"]],"defaults":[],"requirements":[],"hosttokens":[]},"blog":{"tokens":[["variable","\/","[^\/]++","slug"],["text","\/blog-post"]],"defaults":[],"requirements":[],"hosttokens":[["text","localhost"]],"options":{"whatever":false,"angular_controller":"test"}}},"prefix":"","host":"","scheme":""}', $response->getContent());
+    }
+
     public function testConfigCache()
     {
         $routes = new RouteCollection();

--- a/Tests/DependencyInjection/FOSJsRoutingExtensionTest.php
+++ b/Tests/DependencyInjection/FOSJsRoutingExtensionTest.php
@@ -53,6 +53,39 @@ class FOSJsRoutingExtensionTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('{"foo":"bar"}', $serializer->serialize(array('foo' => 'bar'), 'json'));
     }
 
+    public function testExposeOptionsNotSet()
+    {
+        $container = $this->load(array());
+
+        $this->assertTrue($container->hasParameter('fos_js_routing.expose_options'));
+        $parameter = $container->getParameter('fos_js_routing.expose_options');
+
+        $this->assertFalse($parameter);
+    }
+
+    public function provideExposeOptions()
+    {
+        return array(
+            array(true, true),
+            array(false, false),
+        );
+    }
+
+    /**
+     * @param bool $configValue
+     * @param bool $expectedParameter
+     * @dataProvider provideExposeOptions
+     */
+    public function testExposeOptionsSet($configValue, $expectedParameter)
+    {
+        $container = $this->load(array(array('expose_options' => $configValue)));
+
+        $this->assertTrue($container->hasParameter('fos_js_routing.expose_options'));
+        $parameter = $container->getParameter('fos_js_routing.expose_options');
+
+        $this->assertEquals($expectedParameter, $parameter);
+    }
+
     private function load(array $configs)
     {
         $container = new ContainerBuilder();


### PR DESCRIPTION
We needed some options available in our angular application together with the routes configuration. Because we only want one place where routes and their options are defined, we need a way to expose options from the symfony routing definition.

I added a paramater (fos_js_routing.expose_options) to enable this feature. If enabled any exposed_options inside the options of a route are exposed to the javascript routes as a "options" property.

Also I changed the URL from where closure is loaded to githubusercontent.com to get a stable build.

All tests passed: https://travis-ci.org/MyHammer/FOSJsRoutingBundle/builds/114553462
