### PR TITLE
Fix link in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ For documentation, see:
     Resources/doc/
 
 [Read the
-documentation](https://github.com/FriendsOfSymfony/FOSJsRoutingBundle/blob/master/Resources/doc/index.rst)
+documentations](https://github.com/FriendsOfSymfony/FOSJsRoutingBundle/blob/master/Resources/doc)
 
 Contributing
 ------------

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ For documentation, see:
     Resources/doc/
 
 [Read the
-documentation](Resources/doc)
+documentations](Resources/doc)
 
 Contributing
 ------------

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ For documentation, see:
     Resources/doc/
 
 [Read the
-documentation](https://github.com/FriendsOfSymfony/FOSJsRoutingBundle/blob/master/Resources/doc/index.md)
+documentation](https://github.com/FriendsOfSymfony/FOSJsRoutingBundle/blob/master/Resources/doc/index.rst)
 
 Contributing
 ------------

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ For documentation, see:
     Resources/doc/
 
 [Read the
-documentations](https://github.com/FriendsOfSymfony/FOSJsRoutingBundle/blob/master/Resources/doc)
+documentation](Resources/doc)
 
 Contributing
 ------------


### PR DESCRIPTION
-  `Resources/doc/index.md` does not exists
  - https://github.com/FriendsOfSymfony/FOSJsRoutingBundle/blob/master/Resources/doc/index.md
- `Resources/doc/index.rst` exists
  - https://github.com/FriendsOfSymfony/FOSJsRoutingBundle/blob/master/Resources/doc/index.rst
  - But github does not understand what `toctree` is
  - So it's better to open `Resources/doc` directory by the link
    - What I wanted to see was documents under the `Resources/doc`