### PR TITLE
Add format option

### DIFF
--- a/Tests/Command/DumpCommandTest.php
+++ b/Tests/Command/DumpCommandTest.php
@@ -22,7 +22,7 @@ class DumpCommandTest extends \PHPUnit_Framework_TestCase
 
     public function setUp()
     {
-        $this->container = $this->getMock('Symfony\Component\DependencyInjection\ContainerInterface');
+        $this->container = $this->createMock('Symfony\Component\DependencyInjection\ContainerInterface');
 
         $this->extractor = $this->getMockBuilder('FOS\JsRoutingBundle\Extractor\ExposedRoutesExtractor')
             ->disableOriginalConstructor()
@@ -94,6 +94,39 @@ class DumpCommandTest extends \PHPUnit_Framework_TestCase
         $this->assertContains('[file+] /tmp/dump-command-test', $tester->getDisplay());
 
         $this->assertEquals('test({"base_url":"","routes":{"literal":{"tokens":[["text","\/homepage"]],"defaults":[],"requirements":[],"hosttokens":[]},"blog":{"tokens":[["variable","\/","[^\/]++","slug"],["text","\/blog-post"]],"defaults":[],"requirements":[],"hosttokens":[["text","localhost"]]}},"prefix":"","host":"","scheme":""});', file_get_contents('/tmp/dump-command-test'));
+    }
+
+    public function testExecuteFormatOption()
+    {
+        $json = '{"base_url":"","routes":{"literal":{"tokens":[["text","\/homepage"]],"defaults":[],"requirements":[],"hosttokens":[]},"blog":{"tokens":[["variable","\/","[^\/]++","slug"],["text","\/blog-post"]],"defaults":[],"requirements":[],"hosttokens":[["text","localhost"]]}},"prefix":"","host":"","scheme":""}';
+
+        $this->container->expects($this->at(0))
+            ->method('get')
+            ->with('fos_js_routing.extractor')
+            ->will($this->returnValue($this->extractor));
+
+        $this->serializer->expects($this->once())
+            ->method('serialize')
+            ->will($this->returnValue($json));
+
+        $this->container->expects($this->at(1))
+            ->method('get')
+            ->with('fos_js_routing.serializer')
+            ->will($this->returnValue($this->serializer));
+
+        $command = new DumpCommand();
+        $command->setContainer($this->container);
+
+        $tester = new CommandTester($command);
+        $tester->execute(array(
+            '--target' => '/tmp/dump-command-test',
+            '--format' => 'json',
+        ));
+
+        $this->assertContains('Dumping exposed routes.', $tester->getDisplay());
+        $this->assertContains('[file+] /tmp/dump-command-test', $tester->getDisplay());
+
+        $this->assertEquals($json, file_get_contents('/tmp/dump-command-test'));
     }
 
     /**

--- a/Tests/Command/DumpCommandTest.php
+++ b/Tests/Command/DumpCommandTest.php
@@ -22,7 +22,7 @@ class DumpCommandTest extends \PHPUnit_Framework_TestCase
 
     public function setUp()
     {
-        $this->container = $this->createMock('Symfony\Component\DependencyInjection\ContainerInterface');
+        $this->container = $this->getMock('Symfony\Component\DependencyInjection\ContainerInterface');
 
         $this->extractor = $this->getMockBuilder('FOS\JsRoutingBundle\Extractor\ExposedRoutesExtractor')
             ->disableOriginalConstructor()


### PR DESCRIPTION
Adds the `--format` command option. Its default value is `js` but it can also be `json`. If `json`, then a json file is generated instead and the `--callback`option is ignored. This way if the `Router` is imported as a module into the JavaScript the routes data can be passed to it via JSON.
