### PR TITLE
Fix prefix based on locale

### DIFF
--- a/Command/DumpCommand.php
+++ b/Command/DumpCommand.php
@@ -124,7 +124,7 @@ class DumpCommand extends ContainerAwareCommand
             new RoutesResponse(
                 $baseUrl,
                 $this->extractor->getRoutes(),
-                $input->getOption('locale'),
+                $this->extractor->getPrefix($input->getOption('locale')),
                 $this->extractor->getHost(),
                 $this->extractor->getScheme()
             ),


### PR DESCRIPTION
Similar RoutesResponse instantiation is done in https://github.com/FriendsOfSymfony/FOSJsRoutingBundle/blob/master/Controller/Controller.php#L97. But without this fix, outputs from controller and command are not equal, when JMS18nRoutingBundle + `--locale` option are used.
