### PR TITLE
Use default Symfony serializer service when available

### DIFF
--- a/DependencyInjection/FOSJsRoutingExtension.php
+++ b/DependencyInjection/FOSJsRoutingExtension.php
@@ -15,8 +15,10 @@ use Symfony\Component\Config\FileLocator;
 use Symfony\Component\Config\Definition\Processor;
 use Symfony\Component\DependencyInjection\Alias;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Definition;
 use Symfony\Component\DependencyInjection\Loader\XmlFileLoader;
 use Symfony\Component\HttpKernel\DependencyInjection\Extension;
+use Symfony\Component\Serializer\Serializer;
 
 /**
  * FOSJsRoutingExtension

--- a/DependencyInjection/FOSJsRoutingExtension.php
+++ b/DependencyInjection/FOSJsRoutingExtension.php
@@ -15,10 +15,8 @@ use Symfony\Component\Config\FileLocator;
 use Symfony\Component\Config\Definition\Processor;
 use Symfony\Component\DependencyInjection\Alias;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
-use Symfony\Component\DependencyInjection\Definition;
 use Symfony\Component\DependencyInjection\Loader\XmlFileLoader;
 use Symfony\Component\HttpKernel\DependencyInjection\Extension;
-use Symfony\Component\Serializer\Serializer;
 
 /**
  * FOSJsRoutingExtension

--- a/DependencyInjection/SerializerCompilerPass.php
+++ b/DependencyInjection/SerializerCompilerPass.php
@@ -1,0 +1,55 @@
+<?php
+
+/*
+ * This file is part of the FOSJsRoutingBundle package.
+ *
+ * (c) FriendsOfSymfony <http://friendsofsymfony.github.com/>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace FOS\JsRoutingBundle\DependencyInjection;
+
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\Serializer\Encoder\JsonEncoder;
+use Symfony\Component\Serializer\Serializer;
+
+/**
+ * Class SerializerCompilerPass
+ *
+ * @author Miguel Angel Garzón <magarzon@gmail.com>
+ */
+class SerializerCompilerPass implements CompilerPassInterface
+{
+    const SERIALIZER_SERVICE_ID = 'fos_js_routing.serializer';
+
+    /**
+     * @inheritdoc
+     * @param ContainerBuilder $container
+     */
+    public function process(ContainerBuilder $container)
+    {
+        if ($container->hasDefinition(self::SERIALIZER_SERVICE_ID)
+            || $container->hasAlias(self::SERIALIZER_SERVICE_ID)) {
+            return;
+        }
+
+        if ($container->hasDefinition('serializer')) {
+            $container->setAlias(self::SERIALIZER_SERVICE_ID, 'serializer');
+        } else {
+            $definition = $container->register(self::SERIALIZER_SERVICE_ID, Serializer::class);
+            $normalizers = [
+                $container->getDefinition('fos_js_routing.normalizer.route_collection'),
+                $container->getDefinition('fos_js_routing.normalizer.routes_response'),
+                $container->getDefinition('fos_js_routing.denormalizer.route_collection')
+            ];
+            $definition->addArgument($normalizers);
+
+            $encoder = $container->register('fos_js_routing.encoder', JsonEncoder::class);
+            $encoder->setPublic(false);
+            $definition->addArgument(['json' => $encoder]);
+        }
+    }
+}

--- a/DependencyInjection/SerializerCompilerPass.php
+++ b/DependencyInjection/SerializerCompilerPass.php
@@ -13,8 +13,6 @@ namespace FOS\JsRoutingBundle\DependencyInjection;
 
 use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
-use Symfony\Component\Serializer\Encoder\JsonEncoder;
-use Symfony\Component\Serializer\Serializer;
 
 /**
  * Class SerializerCompilerPass
@@ -23,33 +21,31 @@ use Symfony\Component\Serializer\Serializer;
  */
 class SerializerCompilerPass implements CompilerPassInterface
 {
-    const SERIALIZER_SERVICE_ID = 'fos_js_routing.serializer';
-
     /**
      * @inheritdoc
      * @param ContainerBuilder $container
      */
     public function process(ContainerBuilder $container)
     {
-        if ($container->hasDefinition(self::SERIALIZER_SERVICE_ID)
-            || $container->hasAlias(self::SERIALIZER_SERVICE_ID)) {
+        if ($container->hasDefinition('fos_js_routing.serializer')
+            || $container->hasAlias('fos_js_routing.serializer')) {
             return;
         }
 
         if ($container->hasDefinition('serializer')) {
-            $container->setAlias(self::SERIALIZER_SERVICE_ID, 'serializer');
+            $container->setAlias('fos_js_routing.serializer', 'serializer');
         } else {
-            $definition = $container->register(self::SERIALIZER_SERVICE_ID, Serializer::class);
-            $normalizers = [
+            $definition = $container->register('fos_js_routing.serializer', 'Symfony\Component\Serializer\Serializer');
+            $normalizers = array(
                 $container->getDefinition('fos_js_routing.normalizer.route_collection'),
                 $container->getDefinition('fos_js_routing.normalizer.routes_response'),
                 $container->getDefinition('fos_js_routing.denormalizer.route_collection')
-            ];
+            );
             $definition->addArgument($normalizers);
 
-            $encoder = $container->register('fos_js_routing.encoder', JsonEncoder::class);
+            $encoder = $container->register('fos_js_routing.encoder', 'Symfony\Component\Serializer\Encoder\JsonEncoder');
             $encoder->setPublic(false);
-            $definition->addArgument(['json' => $encoder]);
+            $definition->addArgument(array('json' => $encoder));
         }
     }
 }

--- a/FOSJsRoutingBundle.php
+++ b/FOSJsRoutingBundle.php
@@ -11,6 +11,8 @@
 
 namespace FOS\JsRoutingBundle;
 
+use FOS\JsRoutingBundle\DependencyInjection\SerializerCompilerPass;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\HttpKernel\Bundle\Bundle;
 
 /**
@@ -20,4 +22,12 @@ use Symfony\Component\HttpKernel\Bundle\Bundle;
  */
 class FOSJsRoutingBundle extends Bundle
 {
+    /**
+     * @param ContainerBuilder $container
+     */
+    public function build(ContainerBuilder $container)
+    {
+        parent::build($container);
+        $container->addCompilerPass(new SerializerCompilerPass());
+    }
 }

--- a/Resources/config/serializer.xml
+++ b/Resources/config/serializer.xml
@@ -11,22 +11,15 @@
     </parameters>
 
     <services>
-        <service id="fos_js_routing.serializer" class="Symfony\Component\Serializer\Serializer" public="true">
-            <argument type="collection">
-                <argument type="service" id="fos_js_routing.normalizer.route_collection" />
-                <argument type="service" id="fos_js_routing.normalizer.routes_response" />
-                <argument type="service" id="fos_js_routing.denormalizer.route_collection" />
-            </argument>
-            <argument type="collection">
-                <argument key="json" type="service" id="fos_js_routing.encoder" />
-            </argument>
+        <service id="fos_js_routing.normalizer.route_collection" class="%fos_js_routing.normalizer.route_collection.class%" public="false">
+            <tag name="serializer.normalizer" />
+        </service>
+        <service id="fos_js_routing.normalizer.routes_response" class="%fos_js_routing.normalizer.routes_response.class%" public="false">
+            <tag name="serializer.normalizer" />
         </service>
 
-        <service id="fos_js_routing.normalizer.route_collection" class="%fos_js_routing.normalizer.route_collection.class%" public="false" />
-        <service id="fos_js_routing.normalizer.routes_response" class="%fos_js_routing.normalizer.routes_response.class%" public="false" />
-
-        <service id="fos_js_routing.denormalizer.route_collection" class="%fos_js_routing.denormalizer.route_collection.class%" public="false" />
-
-        <service id="fos_js_routing.encoder" class="Symfony\Component\Serializer\Encoder\JsonEncoder" public="false" />
+        <service id="fos_js_routing.denormalizer.route_collection" class="%fos_js_routing.denormalizer.route_collection.class%" public="false">
+            <tag name="serializer.normalizer" />
+        </service>
     </services>
 </container>

--- a/Tests/DependencyInjection/FOSJsRoutingExtensionTest.php
+++ b/Tests/DependencyInjection/FOSJsRoutingExtensionTest.php
@@ -12,6 +12,7 @@
 namespace FOS\JsRoutingBundle\Tests\DependencyInjection;
 
 use FOS\JsRoutingBundle\DependencyInjection\FOSJsRoutingExtension;
+use FOS\JsRoutingBundle\DependencyInjection\SerializerCompilerPass;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 
 class FOSJsRoutingExtensionTest extends \PHPUnit_Framework_TestCase
@@ -59,6 +60,9 @@ class FOSJsRoutingExtensionTest extends \PHPUnit_Framework_TestCase
 
         $extension = new FOSJsRoutingExtension();
         $extension->load($configs, $container);
+
+        $compilerPass = new SerializerCompilerPass();
+        $compilerPass->process($container);
 
         return $container;
     }

--- a/Tests/DependencyInjection/SerializerCompilerPassTest.php
+++ b/Tests/DependencyInjection/SerializerCompilerPassTest.php
@@ -1,0 +1,64 @@
+<?php
+namespace FOS\JsRoutingBundle\Tests\DependencyInjection;
+
+use FOS\JsRoutingBundle\DependencyInjection\FOSJsRoutingExtension;
+use FOS\JsRoutingBundle\DependencyInjection\SerializerCompilerPass;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\Serializer\Serializer;
+
+/**
+ * Class SerializerCompilerPassTest
+ *
+ * @author Miguel Angel Garzón <magarzon@gmail.com>
+ */
+class SerializerCompilerPassTest extends \PHPUnit_Framework_TestCase
+{
+    public function setUp()
+    {
+        if (!class_exists('Symfony\Component\DependencyInjection\ContainerBuilder')) {
+            $this->markTestSkipped('The DependencyInjection component is not available.');
+        }
+    }
+
+    public function testSerializerInConfig()
+    {
+        $container = $this->load([['serializer' => 'test.serializer.service']]);
+
+        $compilerPass = new SerializerCompilerPass();
+        $compilerPass->process($container);
+
+        $this->assertTrue($container->hasAlias('fos_js_routing.serializer'));
+    }
+
+    public function testSerializerDefined()
+    {
+        $container = $this->load([]);
+
+        $container->register('serializer', Serializer::class);
+
+        $compilerPass = new SerializerCompilerPass();
+        $compilerPass->process($container);
+
+        $this->assertTrue($container->hasAlias('fos_js_routing.serializer'));
+    }
+
+    public function testSerializerNotDefined()
+    {
+        $container = $this->load([]);
+
+        $compilerPass = new SerializerCompilerPass();
+        $compilerPass->process($container);
+
+        $this->assertTrue($container->hasDefinition('fos_js_routing.serializer'));
+    }
+
+    private function load(array $configs)
+    {
+        $container = new ContainerBuilder();
+
+        $extension = new FOSJsRoutingExtension();
+        $extension->load($configs, $container);
+
+        return $container;
+    }
+}

--- a/Tests/DependencyInjection/SerializerCompilerPassTest.php
+++ b/Tests/DependencyInjection/SerializerCompilerPassTest.php
@@ -4,7 +4,6 @@ namespace FOS\JsRoutingBundle\Tests\DependencyInjection;
 use FOS\JsRoutingBundle\DependencyInjection\FOSJsRoutingExtension;
 use FOS\JsRoutingBundle\DependencyInjection\SerializerCompilerPass;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
-use Symfony\Component\Serializer\Serializer;
 
 /**
  * Class SerializerCompilerPassTest
@@ -22,7 +21,7 @@ class SerializerCompilerPassTest extends \PHPUnit_Framework_TestCase
 
     public function testSerializerInConfig()
     {
-        $container = $this->load([['serializer' => 'test.serializer.service']]);
+        $container = $this->load(array(array('serializer' => 'test.serializer.service')));
 
         $compilerPass = new SerializerCompilerPass();
         $compilerPass->process($container);
@@ -32,9 +31,9 @@ class SerializerCompilerPassTest extends \PHPUnit_Framework_TestCase
 
     public function testSerializerDefined()
     {
-        $container = $this->load([]);
+        $container = $this->load(array());
 
-        $container->register('serializer', Serializer::class);
+        $container->register('serializer', 'Symfony\Component\Serializer\Serializer');
 
         $compilerPass = new SerializerCompilerPass();
         $compilerPass->process($container);
@@ -44,7 +43,7 @@ class SerializerCompilerPassTest extends \PHPUnit_Framework_TestCase
 
     public function testSerializerNotDefined()
     {
-        $container = $this->load([]);
+        $container = $this->load(array());
 
         $compilerPass = new SerializerCompilerPass();
         $compilerPass->process($container);


### PR DESCRIPTION
Previous to this PR, the bundle created a new service using the same class as the Symfony Serializer, what, apart from redundant, makes problems with autowiring (two services with the same class).

With this PR, if the serializer service exists, it's used, tagging the custom normalizers.

If the serializer services doesn't exist, it's registered as before (more or less, instead from file, is registered using a Compiler Pass)

Tests are ok (updated one and adding another)