### PR TITLE
Update travis.yml with PHP 7.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ php:
   - 5.4
   - 5.6
   - 7.0
-  - hhvm
+  - 7.1
 
 cache:
     directories:
@@ -21,6 +21,8 @@ matrix:
       env: SYMFONY_VERSION='2.8.*'
     - php: 5.6
       env: SYMFONY_VERSION='3.0.*'
+    - php: hhvm
+      dist: trusty
 
 sudo: false
 


### PR DESCRIPTION
As PHP 7.1 is out since December (6 months) I think is useful to test the codebase against it.