### PR TITLE
Fix incompatibility for Symfony <2.2

### DIFF
--- a/Response/RoutesResponse.php
+++ b/Response/RoutesResponse.php
@@ -56,8 +56,8 @@ class RoutesResponse
                 'defaults'     => $defaults,
                 'requirements' => $route->getRequirements(),
                 'hosttokens'   => method_exists($compiledRoute, 'getHostTokens') ? $compiledRoute->getHostTokens() : array(),
-                'methods'      => $route->getMethods(),
-                'schemes'      => $route->getSchemes(),
+                'methods'      => method_exists($route, 'getMethods') ? $route->getMethods() : array(),
+                'schemes'      => method_exists($route, 'getSchemes') ? $route->getSchemes() : array(),
             );
         }
 


### PR DESCRIPTION
Regression introduced in #254 
In Symfony <2.2 (which we still support according to the composer.json), the methods used to fix Symfony 3 support (getSchemes and getSchemes in a Symfony Route) did not exist.
We should test for that as well.