### PR TITLE
[1.x] [insight] Fix "A route should always have a valid HTTP method"

### DIFF
--- a/Resources/config/routing/routing.xml
+++ b/Resources/config/routing/routing.xml
@@ -3,7 +3,7 @@
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xsi:schemaLocation="http://symfony.com/schema/routing http://symfony.com/schema/routing/routing-1.0.xsd">
 
-    <route id="fos_js_routing_js" path="/js/routing.{_format}">
+    <route id="fos_js_routing_js" path="/js/routing.{_format}" methods="GET">
         <default key="_controller">fos_js_routing.controller:indexAction</default>
         <default key="_format">js</default>
         <requirement key="_format">js|json</requirement>


### PR DESCRIPTION
Same as #208, for stable branch