### PR TITLE
Fix trailing commas in array and object

### DIFF
--- a/Resources/js/router.template.js
+++ b/Resources/js/router.template.js
@@ -12,7 +12,7 @@
         // Browser globals (root is window)
         root.Routing = routing.Routing;
         root.fos = {
-            Router: routing.Router,
+            Router: routing.Router
         };
     }
 }(this, function () {

--- a/Resources/public/js/router.js
+++ b/Resources/public/js/router.js
@@ -12,7 +12,7 @@
         // Browser globals (root is window)
         root.Routing = routing.Routing;
         root.fos = {
-            Router: routing.Router,
+            Router: routing.Router
         };
     }
 }(this, function () {


### PR DESCRIPTION
Fix 'Parse error. IE8 (and below) will parse trailing commas in array and object literals incorrectly.'