### PR TITLE
Inform to expose routes annotation before run dump

### DIFF
--- a/Resources/doc/usage.rst
+++ b/Resources/doc/usage.rst
@@ -24,6 +24,10 @@ In applications not using webpack add these two lines in your layout:
 If you are using webpack and Encore to package your assets you will need to use the dump command
 and export your routes to json, this command will create a json file into the ``web/js`` folder:
 
+.. note::
+
+    If you are using annotations for routing you have to expose your routes before running this command
+    
 .. code-block:: bash
 
     # Symfony 3


### PR DESCRIPTION
Maybe I'm wrong but Using Webpack Encore I was trying to use FOSJsRoutingBundle for the first time. After runned dump command I don't have any routes in fos_js_routes.json , I had to expose them in annotations and run again the command. So we can inform people and put a link to the expose route part