### PR TITLE
Fix deprecation notice in symfony 4.1

### DIFF
--- a/Resources/config/routing/routing.xml
+++ b/Resources/config/routing/routing.xml
@@ -4,7 +4,7 @@
     xsi:schemaLocation="http://symfony.com/schema/routing http://symfony.com/schema/routing/routing-1.0.xsd">
 
     <route id="fos_js_routing_js" path="/js/routing.{_format}" methods="GET">
-        <default key="_controller">fos_js_routing.controller:indexAction</default>
+        <default key="_controller">fos_js_routing.controller::indexAction</default>
         <default key="_format">js</default>
         <requirement key="_format">js|json</requirement>
     </route>


### PR DESCRIPTION
With symfony 4.1 came an update to how routes should be declared.  The routing configuration as it now stands triggers a deprecation warning.
I did not test this fix with an older version of symfony.

Documentation: https://github.com/symfony/symfony/blob/master/UPGRADE-4.1.md#frameworkbundle