### PR TITLE
Reference controller with double colon

### DIFF
--- a/Resources/config/routing/routing.xml
+++ b/Resources/config/routing/routing.xml
@@ -4,7 +4,7 @@
     xsi:schemaLocation="http://symfony.com/schema/routing http://symfony.com/schema/routing/routing-1.0.xsd">
 
     <route id="fos_js_routing_js" path="/js/routing.{_format}" methods="GET">
-        <default key="_controller">fos_js_routing.controller:indexAction</default>
+        <default key="_controller">fos_js_routing.controller::indexAction</default>
         <default key="_format">js</default>
         <requirement key="_format">js|json</requirement>
     </route>


### PR DESCRIPTION
since single colon is deprecated since Symfony 4.1

https://github.com/symfony/http-kernel/commit/5ce757f0fb2ef3b6326c730ef77e73df371c9ad2