### PR TITLE
Correct require of fos_js_routes.json

### DIFF
--- a/Resources/doc/usage.rst
+++ b/Resources/doc/usage.rst
@@ -41,7 +41,7 @@ Then within your JavaScript development you can use:
 
 .. code-block:: javascript
 
-    const routes = require('../../web/js/fos_js_routes.json');
+    const routes = require('../../public/js/fos_js_routes.json');
     import Routing from '../../vendor/friendsofsymfony/jsrouting-bundle/Resources/public/js/router.min.js';
 
     Routing.setRoutingData(routes);


### PR DESCRIPTION
On line 44 the require points to the old "web" folder. It should be "public" folder.