### PR TITLE
Remove note about not using Twig in docs

### DIFF
--- a/Resources/doc/usage.rst
+++ b/Resources/doc/usage.rst
@@ -15,11 +15,6 @@ Add these two lines in your layout:
         <script src="<?php echo $view['assets']->getUrl('bundles/fosjsrouting/js/router.js') ?>"></script>
         <script src="<?php echo $view['router']->generate('fos_js_routing_js', array('callback' => 'fos.Router.setData')) ?>"></script>
 
-.. note::
-
-    If you are not using Twig, then it is no problem. What you need is to add
-    the two JavaScript files above loaded at some point in your web page.
-
 Generating URIs
 ---------------
 


### PR DESCRIPTION
It seems it's no longer applicable as both Twig and PHP examples are shown above.