### PR TITLE
Update console commands

### DIFF
--- a/Resources/doc/commands.rst
+++ b/Resources/doc/commands.rst
@@ -10,11 +10,7 @@ to combine the routes with the other JavaScript files in assetic.
 
 .. code-block:: bash
 
-    # Symfony 2
-    $ php app/console fos:js-routing:dump
-    
-    # Symfony 3
-    $ php bin/console fos:js-routing:dump
+    bin/console fos:js-routing:dump
 
 Instead of the line
 
@@ -57,10 +53,6 @@ This command lists all exposed routes:
 
 .. code-block:: bash
 
-    # Symfony 2
-    $ php app/console fos:js-routing:debug [name]
-    
-    # Symfony 3
-    $ php bin/console fos:js-routing:debug [name]
+    bin/console fos:js-routing:debug [name]
 
 .. _`Configuring The Request Context Globally`: http://symfony.com/doc/current/cookbook/console/sending_emails.html#configuring-the-request-context-globally

--- a/Resources/doc/installation.rst
+++ b/Resources/doc/installation.rst
@@ -61,10 +61,6 @@ Execute the following command to publish the assets required by the bundle:
 
 .. code-block:: bash
 
-    # Symfony 2
-    $ php app/console assets:install --symlink web
-
-    # Symfony 3
-    $ php bin/console assets:install --symlink web
+    bin/console assets:install --symlink web
 
 .. _`installation chapter`: https://getcomposer.org/doc/00-intro.md


### PR DESCRIPTION
Remove `php` and only show Symfony 3+ versions.