### PR TITLE
Inform about JMSI18nRoutingBundle compatibility

### DIFF
--- a/Resources/doc/usage.rst
+++ b/Resources/doc/usage.rst
@@ -140,6 +140,24 @@ Moreover, you can configure a list of routes to expose in ``app/config/config.ym
 These routes will be added to the exposed routes. You can use regular expression
 patterns if you don't want to list all your routes name by name.
 
+.. note::
+
+    If you're using `JMSI18nRoutingBundle`_ for your internationalized routes, your exposed routes must now match the bundle locale-prefixed routes, so you could either specify each locale by hand in the routes names, or use a regular expression to match all of your locales at once:
+
+.. code-block:: yaml
+
+    # app/config/config.yml
+    fos_js_routing:
+        routes_to_expose: [ en__RG__route_1, en__RG__route_2, ... ]
+
+.. code-block:: yaml
+
+    # app/config/config.yml
+    fos_js_routing:
+        routes_to_expose: [ '[a-z]{2}__RG__route_1', '[a-z]{2}__RG__route_2', ... ]
+
+Note that `Symfony 4.1 added support for internationalized routes`_ out-of-the-box.
+
 You can prevent to expose a route by configuring it as below:
 
 .. code-block:: yaml
@@ -179,3 +197,6 @@ You can enable HTTP caching as below:
             smaxage: null   # integer value, e.g. 300
             expires: null   # anything that can be fed to "new \DateTime($expires)", e.g. "5 minutes"
             vary: []        # string or array, e.g. "Cookie" or [ Cookie, Accept ]
+
+.. _`JMSI18nRoutingBundle`: https://github.com/schmittjoh/JMSI18nRoutingBundle
+.. _`Symfony 4.1 added support for internationalized routes`: https://symfony.com/blog/new-in-symfony-4-1-internationalized-routing


### PR DESCRIPTION
I've spent the last day trying to figure out why routes could not be dumped anymore to JS in my app.
I'm hoping to save hours of trouble for other developers who would encounter the exact same issue.

[exposed domain feature](https://github.com/FriendsOfSymfony/FOSJsRoutingBundle/commit/ce741512474c654d703833d263d337da28e09fe1) introduced in [FOSJsRoutingBundle 2.3.0](https://github.com/FriendsOfSymfony/FOSJsRoutingBundle/releases/tag/2.3.0) unfortunately prevents dumping [JMSI18nRoutingBundle](https://github.com/schmittjoh/JMSI18nRoutingBundle) internationalized routes.

The exposed routes defined in `app/config/config.yml` are now transformed into a regular expression:

```
(?P<default>route_1|route_2)
```

The problem when using [JMSI18nRoutingBundle](https://github.com/schmittjoh/JMSI18nRoutingBundle) is that the names of the routes are locale-prefixed, so that in the loop through all routes:

```php
foreach ($collection->all() as $name => $route) {
```

The variable `$name` would not be `route_1` or `route_2`, such as defined in `app/config/config.yml`, but rather `en__RG__route_1` or `en__RG__route_2`.

So when populating the `$matches` array using the original routes names and then attempting to get their corresponding domain using the locale-prefixed routes names, well, that returns `null` and continues the loop:

```php
preg_match('#' . $this->pattern . '#', $name, $matches);

if (count($matches) === 0) {
    continue;
}

$domain = $this->getDomainByRouteMatches($matches, $name);

if (is_null($domain)) {
    continue;
}
```

After some thoughts, I've stumbled upon a very easy solution consisting in adapting the routes defined in `app/config/config.yml` so that they would be used as locale-prefixed in the loop!

Tada :)

I hope that it's the right place to inform about this issue, please let me know otherwise, thank you.