### PR TITLE
Bypass cache for exposed routes in debug mode

### DIFF
--- a/Controller/Controller.php
+++ b/Controller/Controller.php
@@ -77,7 +77,7 @@ class Controller
 
         $cache = new ConfigCache($this->exposedRoutesExtractor->getCachePath($request->getLocale()), $this->debug);
 
-        if (!$cache->isFresh()) {
+        if (!$cache->isFresh() || $this->debug) {
             $exposedRoutes    = $this->exposedRoutesExtractor->getRoutes();
             $serializedRoutes = $this->serializer->serialize($exposedRoutes, 'json');
             $cache->write($serializedRoutes, $this->exposedRoutesExtractor->getResources());


### PR DESCRIPTION
I'm having a hard time with this package in local environments, I've included the JS script like this:

```twig
<script src="{{ asset('bundles/fosjsrouting/js/router.min.js') }}"></script>
<script src="{{ path('fos_js_routing_js', { callback: 'fos.Router.setData' }) }}"></script>
```

However, whenever I add, change or remove a route in `config/packages/fos_js_routing.yaml`, I must run `rm -rf var/cache/*/fosJsRouting` (`bin/console cache:clear` doesn't work) to see the applied changes in the response of `fos_js_routing_js`.

It seems like `ConfigCache` is the culprit, so I've made a simple change to bypass the cache when the debug mode is enabled.