### PR TITLE
Fix root dir deprecation and fix PHP 7.4 deprecation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ matrix:
     - php: 7.1
     - php: 7.2
     - php: 7.3
+    - php: 7.4snapshot
     - php: 7.1
       env: SYMFONY_VERSION='3.4.*'
     - php: 7.1

--- a/Command/DumpCommand.php
+++ b/Command/DumpCommand.php
@@ -29,11 +29,6 @@ class DumpCommand extends Command
     protected static $defaultName = 'fos:js-routing:dump';
 
     /**
-     * @var string
-     */
-    private $targetPath;
-
-    /**
      * @var ExposedRoutesExtractorInterface
      */
     private $extractor;
@@ -46,18 +41,18 @@ class DumpCommand extends Command
     /**
      * @var string
      */
-    private $rootDir;
+    private $projectDir;
 
     /**
      * @var string
      */
     private $requestContextBaseUrl;
 
-    public function __construct(ExposedRoutesExtractorInterface $extractor, SerializerInterface $serializer, $rootDir, $requestContextBaseUrl = null)
+    public function __construct(ExposedRoutesExtractorInterface $extractor, SerializerInterface $serializer, $projectDir, $requestContextBaseUrl = null)
     {
         $this->extractor = $extractor;
         $this->serializer = $serializer;
-        $this->rootDir = $rootDir;
+        $this->projectDir = $projectDir;
         $this->requestContextBaseUrl = $requestContextBaseUrl;
 
         parent::__construct();
@@ -145,8 +140,8 @@ class DumpCommand extends Command
         $serializer = $this->serializer;
         $targetPath = $input->getOption('target') ?:
             sprintf(
-                '%s/../web/js/fos_js_routes%s.%s',
-                $this->rootDir,
+                '%s/web/js/fos_js_routes%s.%s',
+                $this->projectDir,
                 empty($domain) ? '' : ('_' . implode('_', $domain)),
                 $input->getOption('format')
             );

--- a/Extractor/ExposedRoutesExtractor.php
+++ b/Extractor/ExposedRoutesExtractor.php
@@ -253,10 +253,10 @@ class ExposedRoutesExtractor implements ExposedRoutesExtractorInterface
 
         foreach ($domainPatterns as $domain => $items) {
 
-            $patterns[] =  '(?P<' . $domain . '>' . implode($items, '|') . ')';
+            $patterns[] =  '(?P<' . $domain . '>' . implode('|', $items) . ')';
         }
 
-        return implode($patterns, '|');
+        return implode('|', $patterns);
     }
 
     /**

--- a/Resources/config/services.xml
+++ b/Resources/config/services.xml
@@ -18,7 +18,7 @@
         <service id="fos_js_routing.dump_command" class="FOS\JsRoutingBundle\Command\DumpCommand">
             <argument type="service" id="fos_js_routing.extractor" />
             <argument type="service" id="fos_js_routing.serializer" />
-            <argument>%kernel.root_dir%</argument>
+            <argument>%kernel.project_dir%</argument>
             <argument>%fos_js_routing.request_context_base_url%</argument>
             <tag name="console.command" />
         </service>

--- a/Tests/Command/DumpCommandTest.php
+++ b/Tests/Command/DumpCommandTest.php
@@ -98,7 +98,7 @@ class DumpCommandTest extends TestCase
     public function testExecuteUnableToCreateDirectory()
     {
         $this->expectException(\RuntimeException::class);
-        $this->expectExceptionMessage('Unable to create directory /root/dir/../web/js');
+        $this->expectExceptionMessage('Unable to create directory /root/dir/web/js');
         $command = new DumpCommand($this->extractor, $this->serializer, '/root/dir');
 
         $tester = new CommandTester($command);

--- a/composer.json
+++ b/composer.json
@@ -17,13 +17,13 @@
     ],
     "require": {
         "php": "^7.1",
-        "symfony/framework-bundle": "~3.0|^4.0|^5.0",
-        "symfony/serializer": "~3.0|^4.0|^5.0",
-        "symfony/console": "~3.0|^4.0|^5.0",
+        "symfony/framework-bundle": "~3.3|^4.0|^5.0",
+        "symfony/serializer": "~3.3|^4.0|^5.0",
+        "symfony/console": "~3.3|^4.0|^5.0",
         "willdurand/jsonp-callback-validator": "~1.0"
     },
     "require-dev": {
-        "symfony/expression-language": "~3.0|^4.0|^5.0",
+        "symfony/expression-language": "~3.3|^4.0|^5.0",
         "symfony/phpunit-bridge": "^3.3|^4.0"
     },
     "autoload": {


### PR DESCRIPTION
Bumps Symfony requirement to 3.3 in order for kernel.project_dir to work