### PR TITLE
Upgrade gulp to version 4

### DIFF
--- a/Resources/gulpfile.js
+++ b/Resources/gulpfile.js
@@ -17,6 +17,4 @@ gulp.task('js', function() {
         .pipe(gulp.dest('public/js'));
 });
 
-gulp.task('default', function() {
-    return gulp.start(['js']);
-});
+gulp.task('default', gulp.series('js'));

--- a/Resources/package.json
+++ b/Resources/package.json
@@ -32,16 +32,17 @@
     "babel-polyfill": "^6.9.1",
     "babel-preset-es2015": "^6.9.0",
     "babel-register": "^6.11.6",
-    "gulp": "^3.9.1",
+    "google-closure-library": "^20171203.0.0",
+    "gulp": "^4.0.2",
     "gulp-babel": "^6.1.2",
     "gulp-rename": "^1.2.2",
     "gulp-uglify": "^1.5.4",
     "gulp-wrap": "^0.13.0",
-    "jasmine": "^2.4.1",
-    "google-closure-library": "^20171203.0.0"
+    "jasmine": "^2.4.1"
   },
   "scripts": {
     "build": "gulp",
     "test": "npm run build && phantomjs js/run_jsunit.js js/router_test.html"
-  }
+  },
+  "dependencies": {}
 }


### PR DESCRIPTION
Hi,

I am proposing this PR in order to upgrade gulp to version 4 because gulp 3.x is deprecated and does not work on latest version of node.

Thank you.