### PR TITLE
Disable auto cache control header

### DIFF
--- a/Util/CacheControlConfig.php
+++ b/Util/CacheControlConfig.php
@@ -12,6 +12,7 @@
 namespace FOS\JsRoutingBundle\Util;
 
 use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpKernel\EventListener\AbstractSessionListener;
 
 class CacheControlConfig
 {
@@ -33,6 +34,8 @@ class CacheControlConfig
         if (empty($this->parameters['enabled'])) {
             return;
         }
+
+        $response->headers->set(AbstractSessionListener::NO_AUTO_CACHE_CONTROL_HEADER, 'true');
 
         $this->parameters['public'] ? $response->setPublic() : $response->setPrivate();
 


### PR DESCRIPTION
Hi. 

When the `fos_js_routing_js` route is behind a firewall, the cache control config is ignored. 

[HTTP Caching and User Sessions](https://symfony.com/doc/current/http_cache.html#http-caching-and-user-sessions)
> Whenever the session is started during a request, Symfony turns the response into a private non-cacheable response. This is the best default behavior to not cache private user information (e.g. a shopping cart, a user profile details, etc.) and expose it to other visitors.

As this route will most probably never be dependent on user session, I think it's safe to disable this behavior 🙂 