### PR TITLE
ensure callback parameter is a string

### DIFF
--- a/Controller/Controller.php
+++ b/Controller/Controller.php
@@ -105,8 +105,7 @@ class Controller
         $content = $this->serializer->serialize($routesResponse, 'json');
 
         if (null !== $callback = $request->query->get('callback')) {
-            $validator = new \JsonpCallbackValidator();
-            if (!$validator->validate($callback)) {
+            if (!is_string($callback) || !(new \JsonpCallbackValidator())->validate($callback)) {
                 throw new HttpException(400, 'Invalid JSONP callback value');
             }
 

--- a/Tests/Controller/ControllerTest.php
+++ b/Tests/Controller/ControllerTest.php
@@ -109,11 +109,17 @@ class ControllerTest extends TestCase
         );
     }
 
-    public function testGenerateWithInvalidCallback()
+    /**
+     * @testWith ["(function xss(x) {evil()})"]
+     *           [["foo", "bar"]]
+     *
+     * @group legacy
+     */
+    public function testGenerateWithInvalidCallback($callback)
     {
         $this->expectException(HttpException::class);
         $controller = new Controller($this->getSerializer(), $this->getExtractor());
-        $controller->indexAction($this->getRequest('/', 'GET', array('callback' => '(function xss(x) {evil()})')), 'json');
+        $controller->indexAction($this->getRequest('/', 'GET', array('callback' => $callback)), 'json');
     }
 
     public function testIndexActionWithoutRoutes()

--- a/Tests/Controller/ControllerTest.php
+++ b/Tests/Controller/ControllerTest.php
@@ -109,17 +109,21 @@ class ControllerTest extends TestCase
         );
     }
 
-    /**
-     * @testWith ["(function xss(x) {evil()})"]
-     *           [["foo", "bar"]]
-     *
-     * @group legacy
-     */
-    public function testGenerateWithInvalidCallback($callback)
+    public function testGenerateWithInvalidCallback()
     {
         $this->expectException(HttpException::class);
         $controller = new Controller($this->getSerializer(), $this->getExtractor());
-        $controller->indexAction($this->getRequest('/', 'GET', array('callback' => $callback)), 'json');
+        $controller->indexAction($this->getRequest('/', 'GET', array('callback' => '(function xss(x) {evil()})')), 'json');
+    }
+
+    /**
+     * @group legacy
+     */
+    public function testGenerateWithNonStringCallback()
+    {
+        $this->expectException(HttpException::class);
+        $controller = new Controller($this->getSerializer(), $this->getExtractor());
+        $controller->indexAction($this->getRequest('/', 'GET', array('callback' => ['foo', 'bar'])), 'json');
     }
 
     public function testIndexActionWithoutRoutes()


### PR DESCRIPTION
Fixes https://github.com/FriendsOfSymfony/FOSJsRoutingBundle/issues/396