### PR TITLE
fix domain replacing locale

### DIFF
--- a/Command/DumpCommand.php
+++ b/Command/DumpCommand.php
@@ -174,6 +174,7 @@ class DumpCommand extends Command
                 $extractor->getHost(),
                 $extractor->getPort(),
                 $extractor->getScheme(),
+                $input->getOption('locale'),
                 $domain
             ),
             'json',


### PR DESCRIPTION
Fix of https://github.com/FriendsOfSymfony/FOSJsRoutingBundle/issues/353
This issue prevent the user from dumping a file of a specific domain.
It also specify in the dumped file the wrong locale, when attempting to do so.