### PR TITLE
Set the branch alias of master to 2.x-dev

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -34,7 +34,7 @@
     },
     "extra": {
         "branch-alias": {
-            "dev-master": "2.0-dev"
+            "dev-master": "2.x-dev"
         }
     }
 }


### PR DESCRIPTION
Right now, composer.json tells composer that the master branch reflects the 2.0 branch of this software. Looking at the versioning strategy of this package, this does not seem to be the case.