### PR TITLE
Fixed dump using domains

### DIFF
--- a/Command/DumpCommand.php
+++ b/Command/DumpCommand.php
@@ -174,6 +174,7 @@ class DumpCommand extends Command
                 $extractor->getHost(),
                 $extractor->getPort(),
                 $extractor->getScheme(),
+                $input->getOption('locale'),
                 $domain
             ),
             'json',


### PR DESCRIPTION
The "domains" parameter was being set as the "locale" parameter for the RoutesResponse constructor. This meant that you couldn't dump routes using domains (the debug command worked tho)