### PR TITLE
Fix docs link & format docs for correct display on Github

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ This is a port of the _symfony 1.x_ plugin: [chCmsExposeRoutingPlugin](https://g
 Documentation
 -------------
 
-For documentation, see:
+For documentation, see: [Resources/doc/index.rst](Resources/doc/index.rst).
 
 [https://symfony.com/doc/master/bundles/FOSJsRoutingBundle/index.html](https://symfony.com/doc/master/bundles/FOSJsRoutingBundle/index.html)
 

--- a/Resources/doc/index.rst
+++ b/Resources/doc/index.rst
@@ -4,9 +4,6 @@ FOSJsRoutingBundle
 This bundle allows to expose Symfony Routes to JavaScript, so you can generate
 relative or absolute URLs in the browser using the same routes as in the backend.
 
-.. toctree::
-    :maxdepth: 1
-
-    installation
-    usage
-    commands
+* `Installation <installation.rst>`_
+* `Usage <usage.rst>`_
+* `Commands <commands.rst>`_

--- a/Resources/doc/usage.rst
+++ b/Resources/doc/usage.rst
@@ -3,17 +3,19 @@ Usage
 
 In applications not using webpack add these two lines in your layout:
 
-.. configuration-block::
+**With Twig:**
 
-    .. code-block:: html+twig
+.. code-block:: twig
 
-        <script src="{{ asset('bundles/fosjsrouting/js/router.min.js') }}"></script>
-        <script src="{{ path('fos_js_routing_js', { callback: 'fos.Router.setData' }) }}"></script>
+    <script src="{{ asset('bundles/fosjsrouting/js/router.min.js') }}"></script>
+    <script src="{{ path('fos_js_routing_js', { callback: 'fos.Router.setData' }) }}"></script>
 
-    .. code-block:: html+php
+**With PHP:**
 
-        <script src="<?php echo $view['assets']->getUrl('bundles/fosjsrouting/js/router.js') ?>"></script>
-        <script src="<?php echo $view['router']->generate('fos_js_routing_js', array('callback' => 'fos.Router.setData')) ?>"></script>
+.. code-block:: html+php
+
+    <script src="<?php echo $view['assets']->getUrl('bundles/fosjsrouting/js/router.js') ?>"></script>
+    <script src="<?php echo $view['router']->generate('fos_js_routing_js', array('callback' => 'fos.Router.setData')) ?>"></script>
 
 .. note::
 
@@ -65,44 +67,46 @@ Or if you want to generate **absolute URLs**:
 
 Assuming some route definitions:
 
-.. configuration-block::
+**With annotations:**
 
-    .. code-block:: php-annotations
+.. code-block:: php
 
-        // src/AppBundle/Controller/DefaultController.php
+    // src/AppBundle/Controller/DefaultController.php
 
-        /**
-         * @Route("/foo/{id}/bar", options={"expose"=true}, name="my_route_to_expose")
-         */
-        public function indexAction($foo) {
-            // ...
-        }
+    /**
+     * @Route("/foo/{id}/bar", options={"expose"=true}, name="my_route_to_expose")
+     */
+    public function indexAction($foo) {
+        // ...
+    }
 
-        /**
-         * @Route("/blog/{page}",
-         *     defaults = { "page" = 1 },
-         *     options = { "expose" = true },
-         *     name = "my_route_to_expose_with_defaults",
-         * )
-         */
-        public function blogAction($page) {
-            // ...
-        }
+    /**
+     * @Route("/blog/{page}",
+     *     defaults = { "page" = 1 },
+     *     options = { "expose" = true },
+     *     name = "my_route_to_expose_with_defaults",
+     * )
+     */
+    public function blogAction($page) {
+        // ...
+    }
 
-    .. code-block:: yaml
+**With YAML:**
 
-        # app/config/routing.yml
-        my_route_to_expose:
-            pattern: /foo/{id}/bar
-            defaults: { _controller: AppBundle:Default:index }
-            options:
-                expose: true
+.. code-block:: yaml
 
-        my_route_to_expose_with_defaults:
-            pattern: /blog/{page}
-            defaults: { _controller: AppBundle:Default:blog, page: 1 }
-            options:
-                expose: true
+    # app/config/routing.yml
+    my_route_to_expose:
+        pattern: /foo/{id}/bar
+        defaults: { _controller: AppBundle:Default:index }
+        options:
+            expose: true
+
+    my_route_to_expose_with_defaults:
+        pattern: /blog/{page}
+        defaults: { _controller: AppBundle:Default:blog, page: 1 }
+        options:
+            expose: true
 
 You can use the ``generate()`` method that way:
 


### PR DESCRIPTION
Hi,

A few days ago the Symfony bundles docs were redesigned, and some bundles were removed from the built docs there.

So here I "fixed" the link by linking to the inner docs, and fixed the index & usage docs.