### PR TITLE
Add return type declaration

### DIFF
--- a/Command/DumpCommand.php
+++ b/Command/DumpCommand.php
@@ -106,7 +106,7 @@ class DumpCommand extends Command
         ;
     }
 
-    protected function execute(InputInterface $input, OutputInterface $output)
+    protected function execute(InputInterface $input, OutputInterface $output) : int
     {
         if(!in_array($input->getOption('format'), array('js', 'json'))) {
             $output->writeln('<error>Invalid format specified. Use js or json.</error>');

--- a/Command/RouterDebugExposedCommand.php
+++ b/Command/RouterDebugExposedCommand.php
@@ -76,7 +76,7 @@ EOF
     /**
      * @see Command
      */
-    protected function execute(InputInterface $input, OutputInterface $output)
+    protected function execute(InputInterface $input, OutputInterface $output) : int
     {
         if ($name = $input->getArgument('name')) {
             /** @var Route $route */

--- a/Serializer/Denormalizer/RouteCollectionDenormalizer.php
+++ b/Serializer/Denormalizer/RouteCollectionDenormalizer.php
@@ -20,7 +20,7 @@ class RouteCollectionDenormalizer implements DenormalizerInterface
     /**
      * {@inheritDoc}
      */
-    public function denormalize($data, $class, $format = null, array $context = array())
+    public function denormalize($data, $class, $format = null, array $context = array()) : mixed
     {
         $collection = new RouteCollection();
 
@@ -43,7 +43,7 @@ class RouteCollectionDenormalizer implements DenormalizerInterface
     /**
      * {@inheritDoc}
      */
-    public function supportsDenormalization($data, $type, $format = null)
+    public function supportsDenormalization($data, $type, $format = null) : bool
     {
         if (!is_array($data)) {
             return false;

--- a/Serializer/Denormalizer/RouteCollectionDenormalizer.php
+++ b/Serializer/Denormalizer/RouteCollectionDenormalizer.php
@@ -20,7 +20,7 @@ class RouteCollectionDenormalizer implements DenormalizerInterface
     /**
      * {@inheritDoc}
      */
-    public function denormalize($data, $class, $format = null, array $context = array()) : mixed
+    public function denormalize($data, $class, $format = null, array $context = array()) : RouteCollection
     {
         $collection = new RouteCollection();
 

--- a/Serializer/Normalizer/RouteCollectionNormalizer.php
+++ b/Serializer/Normalizer/RouteCollectionNormalizer.php
@@ -45,7 +45,7 @@ class RouteCollectionNormalizer implements NormalizerInterface
     /**
      * {@inheritDoc}
      */
-    public function supportsNormalization($data, $format = null)
+    public function supportsNormalization($data, $format = null) : bool
     {
         return $data instanceof RouteCollection;
     }

--- a/Serializer/Normalizer/RoutesResponseNormalizer.php
+++ b/Serializer/Normalizer/RoutesResponseNormalizer.php
@@ -38,7 +38,7 @@ class RoutesResponseNormalizer implements NormalizerInterface
     /**
      * {@inheritDoc}
      */
-    public function supportsNormalization($data, $format = null)
+    public function supportsNormalization($data, $format = null) : bool
     {
         return $data instanceof RoutesResponse;
     }


### PR DESCRIPTION
Suppress messages like:
Method "Symfony\Component\Console\Command\Command::execute()" might add "int" as a native return type declaration in the future. Do the same in child class "FOS\JsRoutingBundle\Command\DumpCommand" now to avoid errors or add an explicit @return annotation to suppress this message.
Method "Symfony\Component\Console\Command\Command::execute()" might add "int" as a native return type declaration in the future. Do the same in child class "FOS\JsRoutingBundle\Command\RouterDebugExposedCommand" now to avoid errors or add an explicit @return annotation to suppress this message.
