### PR TITLE
Improve documentation for dump command

### DIFF
--- a/Command/DumpCommand.php
+++ b/Command/DumpCommand.php
@@ -56,7 +56,7 @@ class DumpCommand extends Command
                 'target',
                 null,
                 InputOption::VALUE_OPTIONAL,
-                'Override the target directory to dump routes in.'
+                'Override the target file to dump routes in.'
             )
             ->addOption(
                 'locale',

--- a/Resources/doc/commands.rst
+++ b/Resources/doc/commands.rst
@@ -48,7 +48,6 @@ Or inside assetic, do
     of one locale at once in your html as each following dump would overwrite the
     data of the previous one.
 
-
 fos:js-routing:debug
 --------------------
 

--- a/Resources/doc/commands.rst
+++ b/Resources/doc/commands.rst
@@ -43,8 +43,11 @@ Or inside assetic, do
 .. tip::
 
     If you are using JMSI18nRoutingBundle, you need to run the command with the
-    ``--locale`` parameter once for each locale you use and adjust your include
-    paths accordingly.
+    ``--locale`` parameter and a custom ``--target`` once for each locale you use.
+    Then adjust your include path accordingly. Note that you can only load the dump
+    of one locale at once in your html as each following dump would overwrite the
+    data of the previous one.
+
 
 fos:js-routing:debug
 --------------------


### PR DESCRIPTION
Fixes #425 

* Improved description of `target` option in `fos:js-routing:dump` command as it actually requires a file and not a directory.

* Improved docs of `fos:js-routing:dump` to make the handling along with JMSI18nRoutingBundle cleared.