### PR TITLE
Allow willdurand/jsonp-callback-validator v2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
         "symfony/framework-bundle": "^5.4|^6.0",
         "symfony/serializer": "^5.4|^6.0.1",
         "symfony/console": "^5.4|^6.0",
-        "willdurand/jsonp-callback-validator": "~1.1"
+        "willdurand/jsonp-callback-validator": "~1.1|^2.0"
     },
     "require-dev": {
         "symfony/expression-language": "^5.4|^6.0",


### PR DESCRIPTION
According to [v2 the release notes](https://github.com/willdurand/JsonpCallbackValidator/releases/tag/v2.0.0), there are no big changes there so everything should be compatible with v1.1.

Fixes #431 