### PR TITLE
use latest PHP 8.0 features

### DIFF
--- a/Command/DumpCommand.php
+++ b/Command/DumpCommand.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * This file is part of the FOSJsRoutingBundle package.
  *
@@ -76,21 +78,23 @@ class DumpCommand extends Command
                 null,
                 InputOption::VALUE_OPTIONAL | InputOption::VALUE_IS_ARRAY,
                 'Specify expose domain',
-                array()
+                []
             )
         ;
     }
 
     protected function execute(InputInterface $input, OutputInterface $output): int
     {
-        if(!in_array($input->getOption('format'), array('js', 'json'))) {
+        if (!in_array($input->getOption('format'), ['js', 'json'])) {
             $output->writeln('<error>Invalid format specified. Use js or json.</error>');
+
             return 1;
         }
 
         $callback = $input->getOption('callback');
-        if(empty($callback)) {
+        if (empty($callback)) {
             $output->writeln('<error>If you include --callback it must not be empty. Do you perhaps want --format=json</error>');
+
             return 1;
         }
 
@@ -98,6 +102,7 @@ class DumpCommand extends Command
         $output->writeln('');
 
         $this->doDump($input, $output);
+
         return 0;
     }
 
@@ -114,18 +119,18 @@ class DumpCommand extends Command
             sprintf(
                 '%s/web/js/fos_js_routes%s.%s',
                 $this->projectDir,
-                empty($domain) ? '' : ('_' . implode('_', $domain)),
+                empty($domain) ? '' : ('_'.implode('_', $domain)),
                 $input->getOption('format')
             );
-        
+
         if (!is_dir($dir = dirname($targetPath))) {
-            $output->writeln('<info>[dir+]</info>  ' . $dir);
+            $output->writeln('<info>[dir+]</info>  '.$dir);
             if (false === @mkdir($dir, 0777, true)) {
-                throw new \RuntimeException('Unable to create directory ' . $dir);
+                throw new \RuntimeException('Unable to create directory '.$dir);
             }
         }
 
-        $output->writeln('<info>[file+]</info> ' . $targetPath);
+        $output->writeln('<info>[file+]</info> '.$targetPath);
 
         $baseUrl = null !== $this->requestContextBaseUrl ?
             $this->requestContextBaseUrl :
@@ -133,9 +138,9 @@ class DumpCommand extends Command
         ;
 
         if ($input->getOption('pretty-print')) {
-            $params = array('json_encode_options' => JSON_PRETTY_PRINT);
+            $params = ['json_encode_options' => JSON_PRETTY_PRINT];
         } else {
-            $params = array();
+            $params = [];
         }
 
         $content = $serializer->serialize(
@@ -153,12 +158,12 @@ class DumpCommand extends Command
             $params
         );
 
-        if('js' == $input->getOption('format')) {
-            $content = sprintf("%s(%s);", $input->getOption('callback'), $content);
+        if ('js' == $input->getOption('format')) {
+            $content = sprintf('%s(%s);', $input->getOption('callback'), $content);
         }
 
         if (false === @file_put_contents($targetPath, $content)) {
-            throw new \RuntimeException('Unable to write file ' . $targetPath);
+            throw new \RuntimeException('Unable to write file '.$targetPath);
         }
     }
 }

--- a/Command/RouterDebugExposedCommand.php
+++ b/Command/RouterDebugExposedCommand.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * This file is part of the FOSJsRoutingBundle package.
  *
@@ -19,8 +21,8 @@ use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Routing\Route;
-use Symfony\Component\Routing\RouterInterface;
 use Symfony\Component\Routing\RouteCollection;
+use Symfony\Component\Routing\RouterInterface;
 
 /**
  * A console command for retrieving information about exposed routes.
@@ -36,20 +38,19 @@ class RouterDebugExposedCommand extends Command
         parent::__construct();
     }
 
-
     /**
      * {@inheritdoc}
      */
     protected function configure(): void
     {
         $this
-            ->setDefinition(array(
+            ->setDefinition([
                 new InputArgument('name', InputArgument::OPTIONAL, 'A route name'),
                 new InputOption('show-controllers', null, InputOption::VALUE_NONE, 'Show assigned controllers in overview'),
                 new InputOption('format', null, InputOption::VALUE_REQUIRED, 'The output format (txt, xml, json, or md)', 'txt'),
                 new InputOption('raw', null, InputOption::VALUE_NONE, 'To output raw route(s)'),
-                new InputOption('domain', null, InputOption::VALUE_OPTIONAL | InputOption::VALUE_IS_ARRAY, 'Specify expose domain', array())
-            ))
+                new InputOption('domain', null, InputOption::VALUE_OPTIONAL | InputOption::VALUE_IS_ARRAY, 'Specify expose domain', []),
+            ])
             ->setName('fos:js-routing:debug')
             ->setDescription('Displays currently exposed routes for an application')
             ->setHelp(<<<EOF
@@ -81,23 +82,24 @@ EOF
             }
 
             $helper = new DescriptorHelper();
-            $helper->describe($output, $route, array(
-                'format'           => $input->getOption('format'),
-                'raw_text'         => $input->getOption('raw'),
+            $helper->describe($output, $route, [
+                'format' => $input->getOption('format'),
+                'raw_text' => $input->getOption('raw'),
                 'show_controllers' => $input->getOption('show-controllers'),
-            ));
+            ]);
         } else {
             $helper = new DescriptorHelper();
-            $helper->describe($output, $this->getRoutes($input->getOption('domain')), array(
-                'format'           => $input->getOption('format'),
-                'raw_text'         => $input->getOption('raw'),
+            $helper->describe($output, $this->getRoutes($input->getOption('domain')), [
+                'format' => $input->getOption('format'),
+                'raw_text' => $input->getOption('raw'),
                 'show_controllers' => $input->getOption('show-controllers'),
-            ));
+            ]);
         }
+
         return 0;
     }
 
-    protected function getRoutes($domain = array()): RouteCollection
+    protected function getRoutes($domain = []): RouteCollection
     {
         $routes = $this->extractor->getRoutes();
 
@@ -108,14 +110,12 @@ EOF
         $targetRoutes = new RouteCollection();
 
         foreach ($routes as $name => $route) {
-
             $expose = $route->getOption('expose');
-            $expose = is_string($expose) ? ($expose === 'true' ? 'default' : $expose) : 'default';
+            $expose = is_string($expose) ? ('true' === $expose ? 'default' : $expose) : 'default';
 
             if (in_array($expose, $domain, true)) {
                 $targetRoutes->add($name, $route);
             }
-
         }
 
         return $targetRoutes;

--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * This file is part of the FOSJsRoutingBundle package.
  *
@@ -11,8 +13,8 @@
 
 namespace FOS\JsRoutingBundle\DependencyInjection;
 
-use Symfony\Component\Config\Definition\ConfigurationInterface;
 use Symfony\Component\Config\Definition\Builder\TreeBuilder;
+use Symfony\Component\Config\Definition\ConfigurationInterface;
 
 /**
  * Configuration class.
@@ -37,8 +39,8 @@ class Configuration implements ConfigurationInterface
                 ->scalarNode('serializer')->cannotBeEmpty()->end()
                 ->arrayNode('routes_to_expose')
                     ->beforeNormalization()
-                        ->ifTrue(function ($v) { return !is_array($v); })
-                        ->then(function ($v) { return array($v); })
+                        ->ifTrue(fn ($v) => !is_array($v))
+                        ->then(fn ($v) => [$v])
                     ->end()
                     ->prototype('scalar')->end()
                 ->end()
@@ -52,8 +54,8 @@ class Configuration implements ConfigurationInterface
                         ->scalarNode('smaxage')->defaultNull()->end()
                         ->arrayNode('vary')
                             ->beforeNormalization()
-                                ->ifTrue(function ($v) { return !is_array($v); })
-                                ->then(function ($v) { return array($v); })
+                                ->ifTrue(fn ($v) => !is_array($v))
+                                ->then(fn ($v) => [$v])
                             ->end()
                             ->prototype('scalar')->end()
                         ->end()

--- a/DependencyInjection/FOSJsRoutingExtension.php
+++ b/DependencyInjection/FOSJsRoutingExtension.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * This file is part of the FOSJsRoutingBundle package.
  *
@@ -11,8 +13,8 @@
 
 namespace FOS\JsRoutingBundle\DependencyInjection;
 
-use Symfony\Component\Config\FileLocator;
 use Symfony\Component\Config\Definition\Processor;
+use Symfony\Component\Config\FileLocator;
 use Symfony\Component\DependencyInjection\Alias;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Loader\XmlFileLoader;
@@ -55,7 +57,7 @@ class FOSJsRoutingExtension extends Extension
         if (isset($config['cache_control'])) {
             $config['cache_control']['enabled'] = true;
         } else {
-            $config['cache_control'] = array('enabled' => false);
+            $config['cache_control'] = ['enabled' => false];
         }
 
         $container->setParameter('fos_js_routing.cache_control', $config['cache_control']);

--- a/Extractor/ExposedRoutesExtractor.php
+++ b/Extractor/ExposedRoutesExtractor.php
@@ -126,7 +126,7 @@ class ExposedRoutesExtractor implements ExposedRoutesExtractorInterface
         $port = '';
         if ($this->usesNonStandardPort()) {
             $method = sprintf('get%sPort', ucfirst($requestContext->getScheme()));
-            $port = $requestContext->$method();
+            $port = (string) $requestContext->$method();
         }
 
         return $port;

--- a/Extractor/ExposedRoutesExtractorInterface.php
+++ b/Extractor/ExposedRoutesExtractorInterface.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * This file is part of the FOSJsRoutingBundle package.
  *
@@ -21,58 +23,51 @@ use Symfony\Component\Routing\RouteCollection;
 interface ExposedRoutesExtractorInterface
 {
     /**
-     * Returns a collection of exposed routes
+     * Returns a collection of exposed routes.
      */
     public function getRoutes(): RouteCollection;
 
     /**
-     * Return the Base URL
+     * Return the Base URL.
      */
     public function getBaseUrl(): string;
 
     /**
-     * Get the route prefix to use, i.e. the language if JMSI18nRoutingBundle is active
+     * Get the route prefix to use, i.e. the language if JMSI18nRoutingBundle is active.
      */
     public function getPrefix(string $locale): string;
 
     /**
-     * Get the host and applicable port from RequestContext
+     * Get the host and applicable port from RequestContext.
      */
     public function getHost(): string;
 
     /**
-     * Get the port from RequestContext, only if non standard port (Eg: "8080")
+     * Get the port from RequestContext, only if non standard port (Eg: "8080").
      */
     public function getPort(): ?string;
 
     /**
-     * Get the scheme from RequestContext
+     * Get the scheme from RequestContext.
      */
     public function getScheme(): string;
 
     /**
-     * Get the cache path for this request
+     * Get the cache path for this request.
      *
      * @param string|null $locale the request locale
-     *
-     * @return string
      */
     public function getCachePath(?string $locale): string;
 
     /**
-     * Return an array of routing resources
+     * Return an array of routing resources.
      *
      * @return ResourceInterface[]
      */
     public function getResources(): array;
 
     /**
-     * Tell whether a route should be considered as exposed
-     *
-     * @param Route  $route
-     * @param string $name
-     *
-     * @return bool
+     * Tell whether a route should be considered as exposed.
      */
     public function isRouteExposed(Route $route, string $name): bool;
 }

--- a/FOSJsRoutingBundle.php
+++ b/FOSJsRoutingBundle.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * This file is part of the FOSJsRoutingBundle package.
  *

--- a/Response/RoutesResponse.php
+++ b/Response/RoutesResponse.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * This file is part of the FOSJsRoutingBundle package.
  *
@@ -22,7 +24,7 @@ class RoutesResponse
                                 private ?string $port = null, private ?string $scheme = null,
                                 private ?string $locale = null, private array $domains = [])
     {
-        $this->routes  = $routes ?: new RouteCollection();
+        $this->routes = $routes ?: new RouteCollection();
     }
 
     public function getBaseUrl(): string
@@ -32,19 +34,17 @@ class RoutesResponse
 
     public function getRoutes(): array
     {
-        $exposedRoutes = array();
+        $exposedRoutes = [];
         foreach ($this->routes->all() as $name => $route) {
-
             if (!$route->hasOption('expose')) {
                 $domain = 'default';
             } else {
                 $domain = $route->getOption('expose');
-                $domain = is_string($domain) ? ($domain === 'true' ? 'default' : $domain) : 'default';
+                $domain = is_string($domain) ? ('true' === $domain ? 'default' : $domain) : 'default';
             }
 
-
-            if (count($this->domains) === 0) {
-                if ($domain !== 'default') {
+            if (0 === count($this->domains)) {
+                if ('default' !== $domain) {
                     continue;
                 }
             } elseif (!in_array($domain, $this->domains, true)) {
@@ -52,7 +52,7 @@ class RoutesResponse
             }
 
             $compiledRoute = $route->compile();
-            $defaults      = array_intersect_key(
+            $defaults = array_intersect_key(
                 $route->getDefaults(),
                 array_fill_keys($compiledRoute->getVariables(), null)
             );
@@ -61,14 +61,14 @@ class RoutesResponse
                 $defaults['_locale'] = $this->locale;
             }
 
-            $exposedRoutes[$name] = array(
-                'tokens'       => $compiledRoute->getTokens(),
-                'defaults'     => $defaults,
+            $exposedRoutes[$name] = [
+                'tokens' => $compiledRoute->getTokens(),
+                'defaults' => $defaults,
                 'requirements' => $route->getRequirements(),
-                'hosttokens'   => method_exists($compiledRoute, 'getHostTokens') ? $compiledRoute->getHostTokens() : array(),
-                'methods'      => $route->getMethods(),
-                'schemes'      => $route->getSchemes(),
-            );
+                'hosttokens' => method_exists($compiledRoute, 'getHostTokens') ? $compiledRoute->getHostTokens() : [],
+                'methods' => $route->getMethods(),
+                'schemes' => $route->getSchemes(),
+            ];
         }
 
         return $exposedRoutes;

--- a/Serializer/Denormalizer/RouteCollectionDenormalizer.php
+++ b/Serializer/Denormalizer/RouteCollectionDenormalizer.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * This file is part of the FOSJsRoutingBundle package.
  *
@@ -55,7 +57,7 @@ class RouteCollectionDenormalizer implements DenormalizerInterface
 
         $values = current($data);
 
-        foreach (array('path', 'defaults', 'requirements', 'options', 'host', 'schemes', 'methods', 'condition') as $key) {
+        foreach (['path', 'defaults', 'requirements', 'options', 'host', 'schemes', 'methods', 'condition'] as $key) {
             if (!isset($values[$key])) {
                 return false;
             }

--- a/Serializer/Normalizer/RouteCollectionNormalizer.php
+++ b/Serializer/Normalizer/RouteCollectionNormalizer.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * This file is part of the FOSJsRoutingBundle package.
  *
@@ -15,28 +17,28 @@ use Symfony\Component\Routing\RouteCollection;
 use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
 
 /**
- * Class RouteCollectionNormalizer
+ * Class RouteCollectionNormalizer.
  */
 class RouteCollectionNormalizer implements NormalizerInterface
 {
     /**
      * {@inheritDoc}
      */
-    public function normalize(mixed $object, string $format = null, array $context = array()): array
+    public function normalize(mixed $object, string $format = null, array $context = []): array
     {
-        $collection = array();
+        $collection = [];
 
         foreach ($object->all() as $name => $route) {
-            $collection[$name] = array(
-                'path'         => $route->getPath(),
-                'host'         => $route->getHost(),
-                'defaults'     => $route->getDefaults(),
+            $collection[$name] = [
+                'path' => $route->getPath(),
+                'host' => $route->getHost(),
+                'defaults' => $route->getDefaults(),
                 'requirements' => $route->getRequirements(),
-                'options'      => $route->getOptions(),
-                'schemes'      => $route->getSchemes(),
-                'methods'      => $route->getMethods(),
-                'condition'    => method_exists($route, 'getCondition') ? $route->getCondition() : '',
-            );
+                'options' => $route->getOptions(),
+                'schemes' => $route->getSchemes(),
+                'methods' => $route->getMethods(),
+                'condition' => method_exists($route, 'getCondition') ? $route->getCondition() : '',
+            ];
         }
 
         return $collection;

--- a/Serializer/Normalizer/RoutesResponseNormalizer.php
+++ b/Serializer/Normalizer/RoutesResponseNormalizer.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * This file is part of the FOSJsRoutingBundle package.
  *
@@ -15,7 +17,7 @@ use FOS\JsRoutingBundle\Response\RoutesResponse;
 use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
 
 /**
- * Class RoutesResponseNormalizer
+ * Class RoutesResponseNormalizer.
  */
 class RoutesResponseNormalizer implements NormalizerInterface
 {
@@ -24,15 +26,15 @@ class RoutesResponseNormalizer implements NormalizerInterface
      */
     public function normalize(mixed $object, string $format = null, array $context = []): array
     {
-        return array(
+        return [
             'base_url' => $object->getBaseUrl(),
-            'routes'   => $object->getRoutes(),
-            'prefix'   => $object->getPrefix(),
-            'host'     => $object->getHost(),
-            'port'     => $object->getPort(),
-            'scheme'   => $object->getScheme(),
-            'locale'   => $object->getLocale(),
-        );
+            'routes' => $object->getRoutes(),
+            'prefix' => $object->getPrefix(),
+            'host' => $object->getHost(),
+            'port' => $object->getPort(),
+            'scheme' => $object->getScheme(),
+            'locale' => $object->getLocale(),
+        ];
     }
 
     /**

--- a/Tests/Command/DumpCommandTest.php
+++ b/Tests/Command/DumpCommandTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * This file is part of the FOSJsRoutingBundle package.
  *
@@ -36,7 +38,7 @@ class DumpCommandTest extends TestCase
             ->getMock();
     }
 
-    public function testExecute()
+    public function testExecute(): void
     {
         $this->serializer->expects($this->once())
             ->method('serialize')
@@ -45,7 +47,7 @@ class DumpCommandTest extends TestCase
         $command = new DumpCommand($this->extractor, $this->serializer, '/root/dir');
 
         $tester = new CommandTester($command);
-        $tester->execute(array('--target' => '/tmp/dump-command-test'));
+        $tester->execute(['--target' => '/tmp/dump-command-test']);
 
         $this->assertStringContainsString('Dumping exposed routes.', $tester->getDisplay());
         $this->assertStringContainsString('[file+] /tmp/dump-command-test', $tester->getDisplay());
@@ -53,7 +55,7 @@ class DumpCommandTest extends TestCase
         $this->assertEquals('fos.Router.setData({"base_url":"","routes":{"literal":{"tokens":[["text","\/homepage"]],"defaults":[],"requirements":[],"hosttokens":[]},"blog":{"tokens":[["variable","\/","[^\/]++","slug"],["text","\/blog-post"]],"defaults":[],"requirements":[],"hosttokens":[["text","localhost"]]}},"prefix":"","host":"","scheme":""});', file_get_contents('/tmp/dump-command-test'));
     }
 
-    public function testExecuteCallbackOption()
+    public function testExecuteCallbackOption(): void
     {
         $this->serializer->expects($this->once())
             ->method('serialize')
@@ -62,10 +64,10 @@ class DumpCommandTest extends TestCase
         $command = new DumpCommand($this->extractor, $this->serializer, '/root/dir');
 
         $tester = new CommandTester($command);
-        $tester->execute(array(
+        $tester->execute([
             '--target' => '/tmp/dump-command-test',
             '--callback' => 'test',
-        ));
+        ]);
 
         $this->assertStringContainsString('Dumping exposed routes.', $tester->getDisplay());
         $this->assertStringContainsString('[file+] /tmp/dump-command-test', $tester->getDisplay());
@@ -73,7 +75,7 @@ class DumpCommandTest extends TestCase
         $this->assertEquals('test({"base_url":"","routes":{"literal":{"tokens":[["text","\/homepage"]],"defaults":[],"requirements":[],"hosttokens":[]},"blog":{"tokens":[["variable","\/","[^\/]++","slug"],["text","\/blog-post"]],"defaults":[],"requirements":[],"hosttokens":[["text","localhost"]]}},"prefix":"","host":"","scheme":""});', file_get_contents('/tmp/dump-command-test'));
     }
 
-    public function testExecuteFormatOption()
+    public function testExecuteFormatOption(): void
     {
         $json = '{"base_url":"","routes":{"literal":{"tokens":[["text","\/homepage"]],"defaults":[],"requirements":[],"hosttokens":[]},"blog":{"tokens":[["variable","\/","[^\/]++","slug"],["text","\/blog-post"]],"defaults":[],"requirements":[],"hosttokens":[["text","localhost"]]}},"prefix":"","host":"","scheme":""}';
 
@@ -84,10 +86,10 @@ class DumpCommandTest extends TestCase
         $command = new DumpCommand($this->extractor, $this->serializer, '/root/dir');
 
         $tester = new CommandTester($command);
-        $tester->execute(array(
+        $tester->execute([
             '--target' => '/tmp/dump-command-test',
             '--format' => 'json',
-        ));
+        ]);
 
         $this->assertStringContainsString('Dumping exposed routes.', $tester->getDisplay());
         $this->assertStringContainsString('[file+] /tmp/dump-command-test', $tester->getDisplay());
@@ -95,17 +97,17 @@ class DumpCommandTest extends TestCase
         $this->assertEquals($json, file_get_contents('/tmp/dump-command-test'));
     }
 
-    public function testExecuteUnableToCreateDirectory()
+    public function testExecuteUnableToCreateDirectory(): void
     {
         $this->expectException(\RuntimeException::class);
         $this->expectExceptionMessage('Unable to create directory /root/dir/web/js');
         $command = new DumpCommand($this->extractor, $this->serializer, '/root/dir');
 
         $tester = new CommandTester($command);
-        $tester->execute(array());
+        $tester->execute([]);
     }
 
-    public function testExecuteUnableToWriteFile()
+    public function testExecuteUnableToWriteFile(): void
     {
         $this->expectException(\RuntimeException::class);
         $this->expectExceptionMessage('Unable to write file /tmp');
@@ -116,6 +118,6 @@ class DumpCommandTest extends TestCase
         $command = new DumpCommand($this->extractor, $this->serializer, '/root/dir');
 
         $tester = new CommandTester($command);
-        $tester->execute(array('--target' => '/tmp'));
+        $tester->execute(['--target' => '/tmp']);
     }
 }

--- a/Tests/Command/RouterDebugExposedCommandTest.php
+++ b/Tests/Command/RouterDebugExposedCommandTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * This file is part of the FOSJsRoutingBundle package.
  *
@@ -33,7 +35,7 @@ class RouterDebugExposedCommandTest extends TestCase
             ->getMock();
     }
 
-    public function testExecute()
+    public function testExecute(): void
     {
         $routes = new RouteCollection();
         $routes->add('literal', new Route('/literal'));
@@ -47,14 +49,14 @@ class RouterDebugExposedCommandTest extends TestCase
         $command = new RouterDebugExposedCommand($this->extractor, $this->router);
 
         $tester = new CommandTester($command);
-        $tester->execute(array());
+        $tester->execute([]);
 
         $this->assertMatchesRegularExpression('/literal(.*ANY){3}.*\/literal/', $tester->getDisplay());
         $this->assertMatchesRegularExpression('/blog_post(.*ANY){3}.*\/blog-post\/{slug}/', $tester->getDisplay());
         $this->assertMatchesRegularExpression('/list(.*ANY){3}.*\/literal/', $tester->getDisplay());
     }
 
-    public function testExecuteWithNameUnknown()
+    public function testExecuteWithNameUnknown(): void
     {
         $this->expectException(\InvalidArgumentException::class);
         $this->expectExceptionMessage('The route "foobar" does not exist.');
@@ -70,10 +72,10 @@ class RouterDebugExposedCommandTest extends TestCase
         $command = new RouterDebugExposedCommand($this->extractor, $this->router);
 
         $tester = new CommandTester($command);
-        $tester->execute(array('name' => 'foobar'));
+        $tester->execute(['name' => 'foobar']);
     }
 
-    public function testExecuteWithNameNotExposed()
+    public function testExecuteWithNameNotExposed(): void
     {
         $this->expectException(\InvalidArgumentException::class);
         $this->expectExceptionMessage('The route "literal" was found, but it is not an exposed route.');
@@ -89,13 +91,13 @@ class RouterDebugExposedCommandTest extends TestCase
         $command = new RouterDebugExposedCommand($this->extractor, $this->router);
 
         $tester = new CommandTester($command);
-        $tester->execute(array('name' => 'literal'));
+        $tester->execute(['name' => 'literal']);
     }
 
-    public function testExecuteWithName()
+    public function testExecuteWithName(): void
     {
         $routes = new RouteCollection();
-        $routes->add('literal', new Route('/literal', array(), array(), array('exposed' => true)));
+        $routes->add('literal', new Route('/literal', [], [], ['exposed' => true]));
         $routes->add('blog_post', new Route('/blog-post/{slug}'));
         $routes->add('list', new Route('/literal'));
 
@@ -110,7 +112,7 @@ class RouterDebugExposedCommandTest extends TestCase
         $command = new RouterDebugExposedCommand($this->extractor, $this->router);
 
         $tester = new CommandTester($command);
-        $tester->execute(array('name' => 'literal'));
+        $tester->execute(['name' => 'literal']);
 
         $this->assertStringContainsString('exposed: true', $tester->getDisplay());
     }

--- a/Tests/Controller/ControllerTest.php
+++ b/Tests/Controller/ControllerTest.php
@@ -136,7 +136,7 @@ class ControllerTest extends TestCase
 
     public function testIndexActionWithoutRoutes(): void
     {
-        $controller = new Controller($this->getSerializer(), $this->getExtractor(), [], sys_get_temp_dir());
+        $controller = new Controller($this->getSerializer(), $this->getExtractor());
         $response = $controller->indexAction($this->getRequest('/'), 'json');
 
         $this->assertEquals('{"base_url":"","routes":[],"prefix":"","host":"","port":null,"scheme":"","locale":"en"}', $response->getContent());
@@ -160,7 +160,7 @@ class ControllerTest extends TestCase
             'vary' => [],
         ];
 
-        $controller = new Controller($this->getSerializer(), $this->getExtractor(), $cacheControlConfig, sys_get_temp_dir());
+        $controller = new Controller($this->getSerializer(), $this->getExtractor(), $cacheControlConfig);
         $response = $controller->indexAction($this->getRequest('/'), 'json');
 
         $this->assertTrue($response->headers->hasCacheControlDirective('public'));

--- a/Tests/Controller/ControllerTest.php
+++ b/Tests/Controller/ControllerTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * This file is part of the FOSJsRoutingBundle package.
  *
@@ -29,7 +31,7 @@ class ControllerTest extends TestCase
 
     public function setUp(): void
     {
-        $this->cachePath = sys_get_temp_dir() . DIRECTORY_SEPARATOR . 'fosJsRouting' . DIRECTORY_SEPARATOR . 'data.json';
+        $this->cachePath = sys_get_temp_dir().DIRECTORY_SEPARATOR.'fosJsRouting'.DIRECTORY_SEPARATOR.'data.json';
     }
 
     public function tearDown(): void
@@ -37,11 +39,11 @@ class ControllerTest extends TestCase
         unlink($this->cachePath);
     }
 
-    public function testIndexAction()
+    public function testIndexAction(): void
     {
         $routes = new RouteCollection();
         $routes->add('literal', new Route('/homepage'));
-        $routes->add('blog', new Route('/blog-post/{slug}', array(), array(), array(), 'localhost'));
+        $routes->add('blog', new Route('/blog-post/{slug}', [], [], [], 'localhost'));
 
         $controller = new Controller(
             $this->getSerializer(),
@@ -53,11 +55,11 @@ class ControllerTest extends TestCase
         $this->assertEquals('{"base_url":"","routes":{"literal":{"tokens":[["text","\/homepage"]],"defaults":[],"requirements":[],"hosttokens":[],"methods":[],"schemes":[]},"blog":{"tokens":[["variable","\/","[^\/]++","slug"],["text","\/blog-post"]],"defaults":[],"requirements":[],"hosttokens":[["text","localhost"]],"methods":[],"schemes":[]}},"prefix":"","host":"","port":null,"scheme":"","locale":"en"}', $response->getContent());
     }
 
-    public function testIndexWithExplicitTokenAction()
+    public function testIndexWithExplicitTokenAction(): void
     {
         $routes = new RouteCollection();
         $routes->add('literal', new Route('/homepage'));
-        $routes->add('blog', new Route('/blog-post/{!slug}', array(), array(), array(), 'localhost'));
+        $routes->add('blog', new Route('/blog-post/{!slug}', [], [], [], 'localhost'));
 
         $controller = new Controller(
             $this->getSerializer(),
@@ -69,11 +71,11 @@ class ControllerTest extends TestCase
         $this->assertEquals('{"base_url":"","routes":{"literal":{"tokens":[["text","\/homepage"]],"defaults":[],"requirements":[],"hosttokens":[],"methods":[],"schemes":[]},"blog":{"tokens":[["variable","\/","[^\/]++","slug",false,true],["text","\/blog-post"]],"defaults":[],"requirements":[],"hosttokens":[["text","localhost"]],"methods":[],"schemes":[]}},"prefix":"","host":"","port":null,"scheme":"","locale":"en"}', $response->getContent());
     }
 
-    public function testIndexActionWithLocalizedRoutes()
+    public function testIndexActionWithLocalizedRoutes(): void
     {
         $routes = new RouteCollection();
         $routes->add('literal', new Route('/homepage'));
-        $routes->add('blog', new Route('/blog-post/{slug}/{_locale}', array(), array(), array(), 'localhost'));
+        $routes->add('blog', new Route('/blog-post/{slug}/{_locale}', [], [], [], 'localhost'));
 
         $controller = new Controller(
             $this->getSerializer(),
@@ -85,7 +87,7 @@ class ControllerTest extends TestCase
         $this->assertEquals('{"base_url":"","routes":{"literal":{"tokens":[["text","\/homepage"]],"defaults":[],"requirements":[],"hosttokens":[],"methods":[],"schemes":[]},"blog":{"tokens":[["variable","\/","[^\/]++","_locale"],["variable","\/","[^\/]++","slug"],["text","\/blog-post"]],"defaults":{"_locale":"en"},"requirements":[],"hosttokens":[["text","localhost"]],"methods":[],"schemes":[]}},"prefix":"","host":"","port":null,"scheme":"","locale":"en"}', $response->getContent());
     }
 
-    public function testConfigCache()
+    public function testConfigCache(): void
     {
         $routes = new RouteCollection();
         $routes->add('literal', new Route('/homepage'));
@@ -106,10 +108,10 @@ class ControllerTest extends TestCase
     /**
      * @dataProvider dataProviderForTestGenerateWithCallback
      */
-    public function testGenerateWithCallback($callback)
+    public function testGenerateWithCallback($callback): void
     {
         $controller = new Controller($this->getSerializer(), $this->getExtractor());
-        $response   = $controller->indexAction($this->getRequest('/', 'GET', array('callback' => $callback)), 'json');
+        $response = $controller->indexAction($this->getRequest('/', 'GET', ['callback' => $callback]), 'json');
 
         $this->assertEquals(
             sprintf('/**/%s({"base_url":"","routes":[],"prefix":"","host":"","port":null,"scheme":"","locale":"en"});', $callback),
@@ -119,23 +121,23 @@ class ControllerTest extends TestCase
 
     public static function dataProviderForTestGenerateWithCallback()
     {
-        return array(
-            array('fos.Router.data'),
-            array('foo'),
-        );
+        return [
+            ['fos.Router.data'],
+            ['foo'],
+        ];
     }
 
-    public function testGenerateWithInvalidCallback()
+    public function testGenerateWithInvalidCallback(): void
     {
         $this->expectException(HttpException::class);
         $controller = new Controller($this->getSerializer(), $this->getExtractor());
-        $controller->indexAction($this->getRequest('/', 'GET', array('callback' => '(function xss(x) {evil()})')), 'json');
+        $controller->indexAction($this->getRequest('/', 'GET', ['callback' => '(function xss(x) {evil()})']), 'json');
     }
 
-    public function testIndexActionWithoutRoutes()
+    public function testIndexActionWithoutRoutes(): void
     {
-        $controller = new Controller($this->getSerializer(), $this->getExtractor(), array(), sys_get_temp_dir());
-        $response   = $controller->indexAction($this->getRequest('/'), 'json');
+        $controller = new Controller($this->getSerializer(), $this->getExtractor(), [], sys_get_temp_dir());
+        $response = $controller->indexAction($this->getRequest('/'), 'json');
 
         $this->assertEquals('{"base_url":"","routes":[],"prefix":"","host":"","port":null,"scheme":"","locale":"en"}', $response->getContent());
         $this->assertEquals(200, $response->getStatusCode());
@@ -147,19 +149,19 @@ class ControllerTest extends TestCase
         $this->assertFalse($response->headers->hasCacheControlDirective('s-maxage'));
     }
 
-    public function testCacheControl()
+    public function testCacheControl(): void
     {
-        $cacheControlConfig = array(
+        $cacheControlConfig = [
             'enabled' => true,
-            'public'  => true,
+            'public' => true,
             'expires' => '2013-10-04 23:59:59 UTC',
-            'maxage'  => 123,
+            'maxage' => 123,
             'smaxage' => 456,
-            'vary'    => array(),
-        );
+            'vary' => [],
+        ];
 
         $controller = new Controller($this->getSerializer(), $this->getExtractor(), $cacheControlConfig, sys_get_temp_dir());
-        $response   = $controller->indexAction($this->getRequest('/'), 'json');
+        $response = $controller->indexAction($this->getRequest('/'), 'json');
 
         $this->assertTrue($response->headers->hasCacheControlDirective('public'));
 
@@ -172,18 +174,18 @@ class ControllerTest extends TestCase
         $this->assertEquals(456, $response->headers->getCacheControlDirective('s-maxage'));
     }
 
-    public function testExposeDomain()
+    public function testExposeDomain(): void
     {
         $routes = new RouteCollection();
         $routes->add('homepage', new Route('/'));
-        $routes->add('admin_index', new Route('/admin', array(), array(),
-            array('expose' => 'admin')));
-        $routes->add('admin_pages', new Route('/admin/path', array(), array(),
-            array('expose' => 'admin')));
-        $routes->add('blog_index', new Route('/blog', array(), array(),
-            array('expose' => 'blog'), 'localhost'));
-        $routes->add('blog_post', new Route('/blog/{slug}', array(), array(),
-            array('expose' => 'blog'), 'localhost'));
+        $routes->add('admin_index', new Route('/admin', [], [],
+            ['expose' => 'admin']));
+        $routes->add('admin_pages', new Route('/admin/path', [], [],
+            ['expose' => 'admin']));
+        $routes->add('blog_index', new Route('/blog', [], [],
+            ['expose' => 'blog'], 'localhost'));
+        $routes->add('blog_post', new Route('/blog/{slug}', [], [],
+            ['expose' => 'blog'], 'localhost'));
 
         $controller = new Controller(
             $this->getSerializer(),
@@ -195,22 +197,22 @@ class ControllerTest extends TestCase
         $this->assertEquals('{"base_url":"","routes":{"homepage":{"tokens":[["text","\/"]],"defaults":[],"requirements":[],"hosttokens":[],"methods":[],"schemes":[]}},"prefix":"","host":"","port":null,"scheme":"","locale":"en"}', $response->getContent());
 
         $response = $controller->indexAction($this->getRequest('/',
-            'GET', array('domain' => 'admin')), 'json');
+            'GET', ['domain' => 'admin']), 'json');
 
         $this->assertEquals('{"base_url":"","routes":{"admin_index":{"tokens":[["text","\/admin"]],"defaults":[],"requirements":[],"hosttokens":[],"methods":[],"schemes":[]},"admin_pages":{"tokens":[["text","\/admin\/path"]],"defaults":[],"requirements":[],"hosttokens":[],"methods":[],"schemes":[]}},"prefix":"","host":"","port":null,"scheme":"","locale":"en"}', $response->getContent());
 
         $response = $controller->indexAction($this->getRequest('/',
-            'GET', array('domain' => 'blog')), 'json');
+            'GET', ['domain' => 'blog']), 'json');
 
         $this->assertEquals('{"base_url":"","routes":{"blog_index":{"tokens":[["text","\/blog"]],"defaults":[],"requirements":[],"hosttokens":[["text","localhost"]],"methods":[],"schemes":[]},"blog_post":{"tokens":[["variable","\/","[^\/]++","slug"],["text","\/blog"]],"defaults":[],"requirements":[],"hosttokens":[["text","localhost"]],"methods":[],"schemes":[]}},"prefix":"","host":"","port":null,"scheme":"","locale":"en"}', $response->getContent());
 
         $response = $controller->indexAction($this->getRequest('/',
-            'GET', array('domain' => 'admin,blog')), 'json');
+            'GET', ['domain' => 'admin,blog']), 'json');
 
         $this->assertEquals('{"base_url":"","routes":{"admin_index":{"tokens":[["text","\/admin"]],"defaults":[],"requirements":[],"hosttokens":[],"methods":[],"schemes":[]},"admin_pages":{"tokens":[["text","\/admin\/path"]],"defaults":[],"requirements":[],"hosttokens":[],"methods":[],"schemes":[]},"blog_index":{"tokens":[["text","\/blog"]],"defaults":[],"requirements":[],"hosttokens":[["text","localhost"]],"methods":[],"schemes":[]},"blog_post":{"tokens":[["variable","\/","[^\/]++","slug"],["text","\/blog"]],"defaults":[],"requirements":[],"hosttokens":[["text","localhost"]],"methods":[],"schemes":[]}},"prefix":"","host":"","port":null,"scheme":"","locale":"en"}', $response->getContent());
 
         $response = $controller->indexAction($this->getRequest('/',
-            'GET', array('domain' => 'default,admin,blog')), 'json');
+            'GET', ['domain' => 'default,admin,blog']), 'json');
 
         $this->assertEquals('{"base_url":"","routes":{"homepage":{"tokens":[["text","\/"]],"defaults":[],"requirements":[],"hosttokens":[],"methods":[],"schemes":[]},"admin_index":{"tokens":[["text","\/admin"]],"defaults":[],"requirements":[],"hosttokens":[],"methods":[],"schemes":[]},"admin_pages":{"tokens":[["text","\/admin\/path"]],"defaults":[],"requirements":[],"hosttokens":[],"methods":[],"schemes":[]},"blog_index":{"tokens":[["text","\/blog"]],"defaults":[],"requirements":[],"hosttokens":[["text","localhost"]],"methods":[],"schemes":[]},"blog_post":{"tokens":[["variable","\/","[^\/]++","slug"],["text","\/blog"]],"defaults":[],"requirements":[],"hosttokens":[["text","localhost"]],"methods":[],"schemes":[]}},"prefix":"","host":"","port":null,"scheme":"","locale":"en"}', $response->getContent());
     }
@@ -262,16 +264,16 @@ class ControllerTest extends TestCase
             $this->markTestSkipped('The Serializer component is not available.');
         }
 
-        return new Serializer(array(
+        return new Serializer([
             new RoutesResponseNormalizer(new RouteCollectionNormalizer()),
             new RouteCollectionNormalizer(),
             new RouteCollectionDenormalizer(),
-        ), array(
-            'json' => new JsonEncoder()
-        ));
+        ], [
+            'json' => new JsonEncoder(),
+        ]);
     }
 
-    private function getRequest($uri, $method = 'GET', $parameters = array(), $cookies = array(), $files = array(), $server = array(), $content = null)
+    private function getRequest($uri, $method = 'GET', $parameters = [], $cookies = [], $files = [], $server = [], $content = null)
     {
         return Request::create($uri, $method, $parameters, $cookies, $files, $server, $content);
     }

--- a/Tests/DependencyInjection/FOSJsRoutingExtensionTest.php
+++ b/Tests/DependencyInjection/FOSJsRoutingExtensionTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * This file is part of the FOSJsRoutingBundle package.
  *
@@ -24,9 +26,9 @@ class FOSJsRoutingExtensionTest extends TestCase
         }
     }
 
-    public function testRouterAlias()
+    public function testRouterAlias(): void
     {
-        $container = $this->load(array());
+        $container = $this->load([]);
 
         $this->assertTrue($container->hasAlias('fos_js_routing.router'));
         $alias = $container->getAlias('fos_js_routing.router');
@@ -35,9 +37,9 @@ class FOSJsRoutingExtensionTest extends TestCase
         $this->assertFalse($alias->isPublic());
     }
 
-    public function testCustomRouterAlias()
+    public function testCustomRouterAlias(): void
     {
-        $container = $this->load(array(array('router' => 'demo_router')));
+        $container = $this->load([['router' => 'demo_router']]);
 
         $this->assertTrue($container->hasAlias('fos_js_routing.router'));
         $alias = $container->getAlias('fos_js_routing.router');
@@ -46,12 +48,12 @@ class FOSJsRoutingExtensionTest extends TestCase
         $this->assertFalse($alias->isPublic());
     }
 
-    public function testLoadSetupsSerializerIfNotGiven()
+    public function testLoadSetupsSerializerIfNotGiven(): void
     {
-        $container = $this->load(array(array()));
+        $container = $this->load([[]]);
 
         $serializer = $container->get('fos_js_routing.serializer');
-        $this->assertEquals('{"foo":"bar"}', $serializer->serialize(array('foo' => 'bar'), 'json'));
+        $this->assertEquals('{"foo":"bar"}', $serializer->serialize(['foo' => 'bar'], 'json'));
     }
 
     private function load(array $configs)

--- a/Tests/Extractor/ExposedRoutesExtractorTest.php
+++ b/Tests/Extractor/ExposedRoutesExtractorTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * This file is part of the FOSJsRoutingBundle package.
  *
@@ -35,7 +37,7 @@ class ExposedRoutesExtractorTest extends TestCase
         $this->cacheDir = sys_get_temp_dir();
     }
 
-    public function testGetRoutes()
+    public function testGetRoutes(): void
     {
         $expected = new RouteCollection();
         $expected->add('literal', new Route('/literal'));
@@ -43,58 +45,58 @@ class ExposedRoutesExtractorTest extends TestCase
         $expected->add('list', new Route('/literal'));
 
         $router = $this->getRouter($expected);
-        $extractor = new ExposedRoutesExtractor($router, array('.*'), $this->cacheDir, array());
+        $extractor = new ExposedRoutesExtractor($router, ['.*'], $this->cacheDir, []);
 
-        $expected->addOptions(array('expose' => 'default'));
+        $expected->addOptions(['expose' => 'default']);
 
         $this->assertEquals($expected, $extractor->getRoutes());
     }
 
-    public function testGetRoutesWithPatterns()
+    public function testGetRoutesWithPatterns(): void
     {
         $expected = new RouteCollection();
-        $expected->add('hello_you', new Route('/foo', array('_controller' => '')));
-        $expected->add('hello_123', new Route('/foo', array('_controller' => '')));
-        $expected->add('hello_world', new Route('/foo', array('_controller' => '')));
+        $expected->add('hello_you', new Route('/foo', ['_controller' => '']));
+        $expected->add('hello_123', new Route('/foo', ['_controller' => '']));
+        $expected->add('hello_world', new Route('/foo', ['_controller' => '']));
 
         $router = $this->getRouter($expected);
 
-        $extractor = new ExposedRoutesExtractor($router, array('hello_.*'), $this->cacheDir, array());
+        $extractor = new ExposedRoutesExtractor($router, ['hello_.*'], $this->cacheDir, []);
         $this->assertCount(3, $extractor->getRoutes(), '3 routes match the pattern: "hello_.*"');
 
-        $extractor = new ExposedRoutesExtractor($router, array('hello_[0-9]{3}'), $this->cacheDir, array());
+        $extractor = new ExposedRoutesExtractor($router, ['hello_[0-9]{3}'], $this->cacheDir, []);
         $this->assertCount(1, $extractor->getRoutes(), '1 routes match the pattern: "hello_[0-9]{3}"');
 
-        $extractor = new ExposedRoutesExtractor($router, array('hello_[0-9]{4}'), $this->cacheDir, array());
+        $extractor = new ExposedRoutesExtractor($router, ['hello_[0-9]{4}'], $this->cacheDir, []);
         $this->assertCount(0, $extractor->getRoutes(), '1 routes match the pattern: "hello_[0-9]{4}"');
 
-        $extractor = new ExposedRoutesExtractor($router, array('hello_.+o.+'), $this->cacheDir, array());
+        $extractor = new ExposedRoutesExtractor($router, ['hello_.+o.+'], $this->cacheDir, []);
         $this->assertCount(2, $extractor->getRoutes(), '2 routes match the pattern: "hello_.+o.+"');
 
-        $extractor = new ExposedRoutesExtractor($router, array('hello_.+o.+', 'hello_123'), $this->cacheDir, array());
+        $extractor = new ExposedRoutesExtractor($router, ['hello_.+o.+', 'hello_123'], $this->cacheDir, []);
         $this->assertCount(3, $extractor->getRoutes(), '3 routes match patterns: "hello_.+o.+" and "hello_123"');
 
-        $extractor = new ExposedRoutesExtractor($router, array('hello_.+o.+', 'hello_$'), $this->cacheDir, array());
+        $extractor = new ExposedRoutesExtractor($router, ['hello_.+o.+', 'hello_$'], $this->cacheDir, []);
         $this->assertCount(2, $extractor->getRoutes(), '2 routes match patterns: "hello_.+o.+" and "hello_"');
 
-        $extractor = new ExposedRoutesExtractor($router, array(), $this->cacheDir, array());
+        $extractor = new ExposedRoutesExtractor($router, [], $this->cacheDir, []);
         $this->assertCount(0, $extractor->getRoutes(), 'No patterns so no matched routes');
     }
 
-    public function testGetCachePath()
+    public function testGetCachePath(): void
     {
         $router = $this->getMockBuilder('Symfony\\Component\\Routing\\Router')
             ->disableOriginalConstructor()
             ->getMock();
 
-        $extractor = new ExposedRoutesExtractor($router, array(), $this->cacheDir, array());
-        $this->assertEquals($this->cacheDir . DIRECTORY_SEPARATOR . 'fosJsRouting' . DIRECTORY_SEPARATOR . 'data.json', $extractor->getCachePath(''));
+        $extractor = new ExposedRoutesExtractor($router, [], $this->cacheDir, []);
+        $this->assertEquals($this->cacheDir.DIRECTORY_SEPARATOR.'fosJsRouting'.DIRECTORY_SEPARATOR.'data.json', $extractor->getCachePath(''));
     }
 
     /**
      * @dataProvider provideTestGetHostOverHttp
      */
-    public function testGetHostOverHttp($host, $httpPort, $expected)
+    public function testGetHostOverHttp($host, $httpPort, $expected): void
     {
         $requestContext = new RequestContext('/app_dev.php', 'GET', $host, 'http', $httpPort);
 
@@ -105,7 +107,7 @@ class ExposedRoutesExtractorTest extends TestCase
             ->method('getContext')
             ->will($this->returnValue($requestContext));
 
-        $extractor = new ExposedRoutesExtractor($router, array(), $this->cacheDir, array());
+        $extractor = new ExposedRoutesExtractor($router, [], $this->cacheDir, []);
 
         $this->assertEquals($expected, $extractor->getHost());
     }
@@ -115,16 +117,16 @@ class ExposedRoutesExtractorTest extends TestCase
      */
     public function provideTestGetHostOverHttp()
     {
-        return array(
-            'HTTP Standard' => array('127.0.0.1', 80, '127.0.0.1'),
-            'HTTP Non-Standard' => array('127.0.0.1', 8888, '127.0.0.1:8888'),
-        );
+        return [
+            'HTTP Standard' => ['127.0.0.1', 80, '127.0.0.1'],
+            'HTTP Non-Standard' => ['127.0.0.1', 8888, '127.0.0.1:8888'],
+        ];
     }
 
     /**
      * @dataProvider provideTestGetHostOverHttps
      */
-    public function testGetHostOverHttps($host, $httpsPort, $expected)
+    public function testGetHostOverHttps($host, $httpsPort, $expected): void
     {
         $requestContext = new RequestContext('/app_dev.php', 'GET', $host, 'https', 80, $httpsPort);
 
@@ -135,12 +137,12 @@ class ExposedRoutesExtractorTest extends TestCase
             ->method('getContext')
             ->will($this->returnValue($requestContext));
 
-        $extractor = new ExposedRoutesExtractor($router, array(), $this->cacheDir, array());
+        $extractor = new ExposedRoutesExtractor($router, [], $this->cacheDir, []);
 
         $this->assertEquals($expected, $extractor->getHost());
     }
 
-    public function testExposeFalse()
+    public function testExposeFalse(): void
     {
         $expected = new RouteCollection();
         $expected->add('user_public_1', new Route('/user/public/1'));
@@ -152,18 +154,16 @@ class ExposedRoutesExtractorTest extends TestCase
         $expected->add('user_secret_2', new Route('/user/secret/2', [], [], ['expose' => 'false']));
 
         $router = $this->getRouter($expected);
-        $extractor = new ExposedRoutesExtractor($router, array('user_.+'), $this->cacheDir, []);
+        $extractor = new ExposedRoutesExtractor($router, ['user_.+'], $this->cacheDir, []);
 
         $this->assertCount(5, $extractor->getRoutes());
 
         foreach ($expected->all() as $name => $route) {
-
             if (in_array($name, ['user_secret_1', 'user_secret_2'])) {
                 $this->assertFalse($extractor->isRouteExposed($route, $name));
             } else {
                 $this->assertTrue($extractor->isRouteExposed($route, $name));
             }
-
         }
     }
 
@@ -172,14 +172,14 @@ class ExposedRoutesExtractorTest extends TestCase
      */
     public function provideTestGetHostOverHttps()
     {
-        return array(
-            'HTTPS Standard' => array('127.0.0.1', 443, '127.0.0.1'),
-            'HTTPS Non-Standard' => array('127.0.0.1', 9876, '127.0.0.1:9876'),
-        );
+        return [
+            'HTTPS Standard' => ['127.0.0.1', 443, '127.0.0.1'],
+            'HTTPS Non-Standard' => ['127.0.0.1', 9876, '127.0.0.1:9876'],
+        ];
     }
 
     /**
-     * Get a mock object which represents a Router
+     * Get a mock object which represents a Router.
      *
      * @return \Symfony\Component\Routing\Router
      */

--- a/Tests/Serializer/Normalizer/RouteCollectionNormalizerTest.php
+++ b/Tests/Serializer/Normalizer/RouteCollectionNormalizerTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * This file is part of the FOSJsRoutingBundle package.
  *
@@ -13,15 +15,15 @@ namespace FOS\JsRoutingBundle\Tests\Serializer\Normalizer;
 
 use FOS\JsRoutingBundle\Serializer\Normalizer\RouteCollectionNormalizer;
 use PHPUnit\Framework\TestCase;
-use Symfony\Component\Routing\RouteCollection;
 use Symfony\Component\Routing\Route;
+use Symfony\Component\Routing\RouteCollection;
 
 /**
- * Class RouteCollectionNormalizerTest
+ * Class RouteCollectionNormalizerTest.
  */
 class RouteCollectionNormalizerTest extends TestCase
 {
-    public function testSupportsNormalization()
+    public function testSupportsNormalization(): void
     {
         $normalizer = new RouteCollectionNormalizer();
 
@@ -29,7 +31,7 @@ class RouteCollectionNormalizerTest extends TestCase
         $this->assertTrue($normalizer->supportsNormalization(new RouteCollection()));
     }
 
-    public function testNormalize()
+    public function testNormalize(): void
     {
         $normalizer = new RouteCollectionNormalizer();
 
@@ -38,44 +40,44 @@ class RouteCollectionNormalizerTest extends TestCase
         $routes->add('blog_post', new Route('/blog-post/{slug}'));
         $routes->add('list', new Route('/literal'));
 
-        $expected = array(
-            'literal' => array(
-                'path'         => '/literal',
-                'host'         => '',
-                'defaults'     => array(),
-                'requirements' => array(),
-                'options'      => array(
-                    'compiler_class' => 'Symfony\Component\Routing\RouteCompiler'
-                ),
-                'schemes'   => array(),
-                'methods'   => array(),
-                'condition' => '',
-            ),
-            'blog_post' => array(
-                'path'         => '/blog-post/{slug}',
-                'host'         => '',
-                'defaults'     => array(),
-                'requirements' => array(),
-                'options'      => array(
-                    'compiler_class' => 'Symfony\Component\Routing\RouteCompiler'
-                ),
-                'schemes'   => array(),
-                'methods'   => array(),
-                'condition' => '',
-            ),
-            'list' => array(
-                'path'         => '/literal',
-                'host'         => '',
-                'defaults'     => array(),
-                'requirements' => array(),
-                'options'      => array(
+        $expected = [
+            'literal' => [
+                'path' => '/literal',
+                'host' => '',
+                'defaults' => [],
+                'requirements' => [],
+                'options' => [
                     'compiler_class' => 'Symfony\Component\Routing\RouteCompiler',
-                ),
-                'schemes'   => array(),
-                'methods'   => array(),
+                ],
+                'schemes' => [],
+                'methods' => [],
                 'condition' => '',
-            ),
-        );
+            ],
+            'blog_post' => [
+                'path' => '/blog-post/{slug}',
+                'host' => '',
+                'defaults' => [],
+                'requirements' => [],
+                'options' => [
+                    'compiler_class' => 'Symfony\Component\Routing\RouteCompiler',
+                ],
+                'schemes' => [],
+                'methods' => [],
+                'condition' => '',
+            ],
+            'list' => [
+                'path' => '/literal',
+                'host' => '',
+                'defaults' => [],
+                'requirements' => [],
+                'options' => [
+                    'compiler_class' => 'Symfony\Component\Routing\RouteCompiler',
+                ],
+                'schemes' => [],
+                'methods' => [],
+                'condition' => '',
+            ],
+        ];
 
         $this->assertSame($expected, $normalizer->normalize($routes));
     }

--- a/Tests/Serializer/Normalizer/RoutesResponseNormalizerTest.php
+++ b/Tests/Serializer/Normalizer/RoutesResponseNormalizerTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * This file is part of the FOSJsRoutingBundle package.
  *
@@ -17,10 +19,10 @@ use PHPUnit\Framework\TestCase;
 
 class RoutesResponseNormalizerTest extends TestCase
 {
-    public function testSupportsNormalization()
+    public function testSupportsNormalization(): void
     {
         $normalizer = new RoutesResponseNormalizer(new RouteCollectionNormalizer());
-        $response   = $this->getMockBuilder('FOS\JsRoutingBundle\Response\RoutesResponse')
+        $response = $this->getMockBuilder('FOS\JsRoutingBundle\Response\RoutesResponse')
             ->disableOriginalConstructor()
             ->getMock();
 
@@ -28,16 +30,16 @@ class RoutesResponseNormalizerTest extends TestCase
         $this->assertTrue($normalizer->supportsNormalization($response));
     }
 
-    public function testNormalize()
+    public function testNormalize(): void
     {
         $normalizer = new RoutesResponseNormalizer(new RouteCollectionNormalizer());
-        $response   = $this->getMockBuilder('FOS\JsRoutingBundle\Response\RoutesResponse')
+        $response = $this->getMockBuilder('FOS\JsRoutingBundle\Response\RoutesResponse')
             ->disableOriginalConstructor()
             ->getMock();
 
         $response->expects($this->once())
             ->method('getRoutes')
-            ->will($this->returnValue(array()));
+            ->will($this->returnValue([]));
 
         $response->expects($this->once())
             ->method('getBaseUrl')
@@ -59,15 +61,15 @@ class RoutesResponseNormalizerTest extends TestCase
             ->method('getLocale')
             ->will($this->returnValue('locale'));
 
-        $expected = array(
+        $expected = [
             'base_url' => 'baseUrl',
-            'routes'   => array(),
-            'prefix'   => 'prefix',
-            'host'     => 'host',
-            'port'     => null,
-            'scheme'   => 'scheme',
-            'locale'   => 'locale',
-        );
+            'routes' => [],
+            'prefix' => 'prefix',
+            'host' => 'host',
+            'port' => null,
+            'scheme' => 'scheme',
+            'locale' => 'locale',
+        ];
 
         $this->assertSame($expected, $normalizer->normalize($response));
     }

--- a/Util/CacheControlConfig.php
+++ b/Util/CacheControlConfig.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * This file is part of the FOSJsRoutingBundle package.
  *
@@ -15,7 +17,6 @@ use Symfony\Component\HttpFoundation\Response;
 
 class CacheControlConfig
 {
-
     public function __construct(private array $parameters = [])
     {
     }
@@ -36,7 +37,7 @@ class CacheControlConfig
             $response->setSharedMaxAge($this->parameters['smaxage']);
         }
 
-        if ($this->parameters['expires'] !== null) {
+        if (null !== $this->parameters['expires']) {
             $response->setExpires(new \DateTime($this->parameters['expires']));
         }
 


### PR DESCRIPTION
I noticed we are still using old-style `array()` syntax and some other legacy features so I run PHP-CS-Fixer with `@PHP80Migration:risky,@Symfony` to make use of latest features like arrow functions and `strict_types` 🚀 

Please also take not of changes in tests - adding strict typing revealed some bugs there.