### PR TITLE
use Flex by default

### DIFF
--- a/Command/DumpCommand.php
+++ b/Command/DumpCommand.php
@@ -112,12 +112,12 @@ class DumpCommand extends Command
         $serializer = $this->serializer;
         $targetPath = $input->getOption('target') ?:
             sprintf(
-                '%s/web/js/fos_js_routes%s.%s',
+                '%s/public/js/fos_js_routes%s.%s',
                 $this->projectDir,
                 empty($domain) ? '' : ('_' . implode('_', $domain)),
                 $input->getOption('format')
             );
-        
+
         if (!is_dir($dir = dirname($targetPath))) {
             $output->writeln('<info>[dir+]</info>  ' . $dir);
             if (false === @mkdir($dir, 0777, true)) {

--- a/Resources/doc/usage.rst
+++ b/Resources/doc/usage.rst
@@ -24,19 +24,19 @@ In applications not using webpack add these two lines in your layout:
 
 
 If you are using webpack and Encore to package your assets you will need to use the dump command
-and export your routes to json, this command will create a json file into the ``web/js`` folder:
+and export your routes to json, this command will create a json file into the ``public/js`` folder:
 
 .. code-block:: bash
 
     bin/console fos:js-routing:dump --format=json
 
-If you are using Flex, probably you want to dump your routes into the ``public`` folder
-instead of ``web``, to achieve this you can set the ``target`` parameter:
+If you are not using Flex, probably you want to dump your routes into the ``web`` folder
+instead of ``public``, to achieve this you can set the ``target`` parameter:
 
 .. code-block:: bash
 
     # Symfony Flex
-    bin/console fos:js-routing:dump --format=json --target=public/js/fos_js_routes.json
+    bin/console fos:js-routing:dump --format=json --target=web/js/fos_js_routes.json
 
 Then within your JavaScript development you can use:
 

--- a/Tests/Command/DumpCommandTest.php
+++ b/Tests/Command/DumpCommandTest.php
@@ -98,7 +98,7 @@ class DumpCommandTest extends TestCase
     public function testExecuteUnableToCreateDirectory()
     {
         $this->expectException(\RuntimeException::class);
-        $this->expectExceptionMessage('Unable to create directory /root/dir/web/js');
+        $this->expectExceptionMessage('Unable to create directory /root/dir/public/js');
         $command = new DumpCommand($this->extractor, $this->serializer, '/root/dir');
 
         $tester = new CommandTester($command);


### PR DESCRIPTION
Since we dropped Symfony <5.4 in v3, I believe we should have updated default dump target path to `public`. This is because Flex is now a default way to create a Symfony app and it might be confusing for new users to explicitly set it using `target` option.