### PR TITLE
Changed ExposedRoutesExtractor to handle mkdir warnings

### DIFF
--- a/Extractor/ExposedRoutesExtractor.php
+++ b/Extractor/ExposedRoutesExtractor.php
@@ -147,7 +147,9 @@ class ExposedRoutesExtractor implements ExposedRoutesExtractorInterface
     {
         $cachePath = $this->cacheDir.DIRECTORY_SEPARATOR.'fosJsRouting';
         if (!file_exists($cachePath)) {
-            mkdir($cachePath);
+            if (false === @mkdir($cachePath)) {
+                throw new \RuntimeException('Unable to create Cache directory ' . $cachePath);
+            }
         }
 
         if (isset($this->bundles['JMSI18nRoutingBundle'])) {


### PR DESCRIPTION
Hi!

I believe there's an issue in this bundle that can occur when the `Controller:indexAction` is invoked for the first time.

We have a test suite with browser tests that runs in parallel and from time to time we see failures like this in the logs:
```
request.CRITICAL: Uncaught PHP Exception ErrorException: 
"Warning: mkdir(): File exists" at /var/www/vendor/friendsofsymfony/jsrouting-bundle/Extractor/ExposedRoutesExtractor.php line 179 
{"exception":"[object] (ErrorException(code: 0): 
Warning: mkdir(): File exists at /var/www/vendor/friendsofsymfony/jsrouting-bundle/Extractor/ExposedRoutesExtractor.php:179)"} []
```

There's a race condition in the code which can lead to this error - my suggestion is to make it a bit more bullet-proof.

The other `mkdir` usage in this package is already "hardened":
https://github.com/FriendsOfSymfony/FOSJsRoutingBundle/blob/089c7380eaaacf776f99c6fbf51f787d395b2013/Command/DumpCommand.php#L126-L131

and I've based my solution on that.
