### PR TITLE
Handle nullable route defaults

### DIFF
--- a/Resources/js/router.test.js
+++ b/Resources/js/router.test.js
@@ -603,3 +603,32 @@ function testGenerateWithPortInHost() {
 
   assertEquals('/foo/', router.generate('homepage'));
 }
+
+function testGenerateWithNullableDefaults() {
+    var router = new fos.Router({ base_url: '/foo' }, {
+        homepage: {
+            tokens: [
+                ['text', '/'],
+                [
+                    'variable',
+                    '/',
+                    '\d*',
+                    'id',
+                    true,
+                ],
+            ],
+            defaults: {
+                'id': null,
+            },
+            requirements: {
+                'id': '\d*',
+            },
+            hosttokens: [],
+            methods: [],
+            schemes: [],
+        },
+    });
+
+    assertEquals('/foo//', router.generate('homepage'));
+    assertEquals('/foo/1234/', router.generate('homepage', { id: 1234 }));
+}

--- a/Resources/js/router.ts
+++ b/Resources/js/router.ts
@@ -1,5 +1,5 @@
 export interface RouteDefaults {
-  [index: string]: string;
+  [index: string]: string | null;
 }
 
 export interface RouteRequirements {

--- a/Resources/ts/router.d.ts
+++ b/Resources/ts/router.d.ts
@@ -1,5 +1,5 @@
 export interface RouteDefaults {
-    [index: string]: string;
+    [index: string]: string | null;
 }
 export interface RouteRequirements {
     [index: string]: string;


### PR DESCRIPTION
Since Symfony 4.1, route parameters may declared optional/nullable:

>To give a `null` default value to any parameter, add nothing after the `?` character (e.g. `/blog/{page?}`). If you do this, don't forget to update the types of the related controller arguments to allow passing `null` values (e.g. replace `int $page` by `?int $page`).

Such parameters are then represented in generated list of routes in the `defaults` node like this (JSON):

```json
"defaults": {
     "page": null
},
```

Unfortunately the `RouteDefaults` interface only allows value to be a `string`. This PR adds support of `null` to the interface to comply with the Symfony behavior.