### PR TITLE
Remove deprecated `$defaultName`

### DIFF
--- a/Command/DumpCommand.php
+++ b/Command/DumpCommand.php
@@ -28,8 +28,6 @@ use Symfony\Component\Serializer\SerializerInterface;
  */
 class DumpCommand extends Command
 {
-    protected static $defaultName = 'fos:js-routing:dump';
-
     public function __construct(private ExposedRoutesExtractorInterface $extractor, private SerializerInterface $serializer, private string $projectDir, private ?string $requestContextBaseUrl = null)
     {
         parent::__construct();

--- a/Command/RouterDebugExposedCommand.php
+++ b/Command/RouterDebugExposedCommand.php
@@ -31,8 +31,6 @@ use Symfony\Component\Routing\RouterInterface;
  */
 class RouterDebugExposedCommand extends Command
 {
-    protected static $defaultName = 'fos:js-routing:debug';
-
     public function __construct(private ExposedRoutesExtractorInterface $extractor, private RouterInterface $router)
     {
         parent::__construct();


### PR DESCRIPTION
Symfony 6.1 depracates usage of `\Symfony\Component\Console\Command\Command::$defaultName` - the name is already configured in `configure()`.

See: https://github.com/symfony/symfony/blob/6.1/UPGRADE-6.1.md