### PR TITLE
Fix SF6.1 deprecations

### DIFF
--- a/Serializer/Denormalizer/RouteCollectionDenormalizer.php
+++ b/Serializer/Denormalizer/RouteCollectionDenormalizer.php
@@ -45,7 +45,7 @@ class RouteCollectionDenormalizer implements DenormalizerInterface
     /**
      * {@inheritDoc}
      */
-    public function supportsDenormalization(mixed $data, string $type, string $format = null): bool
+    public function supportsDenormalization(mixed $data, string $type, string $format = null, array $context = []): bool
     {
         if (!is_array($data)) {
             return false;

--- a/Serializer/Normalizer/RouteCollectionNormalizer.php
+++ b/Serializer/Normalizer/RouteCollectionNormalizer.php
@@ -47,7 +47,7 @@ class RouteCollectionNormalizer implements NormalizerInterface
     /**
      * {@inheritDoc}
      */
-    public function supportsNormalization(mixed $data, string $format = null): bool
+    public function supportsNormalization(mixed $data, string $format = null, array $context = []): bool
     {
         return $data instanceof RouteCollection;
     }

--- a/Serializer/Normalizer/RoutesResponseNormalizer.php
+++ b/Serializer/Normalizer/RoutesResponseNormalizer.php
@@ -40,7 +40,7 @@ class RoutesResponseNormalizer implements NormalizerInterface
     /**
      * {@inheritDoc}
      */
-    public function supportsNormalization(mixed $data, string $format = null): bool
+    public function supportsNormalization(mixed $data, string $format = null, array $context = []): bool
     {
         return $data instanceof RoutesResponse;
     }


### PR DESCRIPTION
Fixes deprecation in Normalizer / Denormalizer:

The "FOS\JsRoutingBundle\Serializer\Normalizer\RouteCollectionNormalizer::supportsNormalization()" method will require a new "array $context" argument in the next major version of its interface "Symfony\Component\Serializer\Normalizer\NormalizerInterface", not defining it is deprecated.

The "FOS\JsRoutingBundle\Serializer\Normalizer\RoutesResponseNormalizer::supportsNormalization()" method will require a new "array $context" argument in the next major version of its interface "Symfony\Component\Serializer\Normalizer\NormalizerInterface", not defining it is deprecated.

The "FOS\JsRoutingBundle\Serializer\Denormalizer\RouteCollectionDenormalizer::supportsDenormalization()" method will require a new "array $context" argument in the next major version of its interface "Symfony\Component\Serializer\Normalizer\DenormalizerInterface", not defining it is deprecated.

