### PR TITLE
Fix Symfony 6.1 deprecations

### DIFF
--- a/Command/DumpCommand.php
+++ b/Command/DumpCommand.php
@@ -15,6 +15,7 @@ namespace FOS\JsRoutingBundle\Command;
 
 use FOS\JsRoutingBundle\Extractor\ExposedRoutesExtractorInterface;
 use FOS\JsRoutingBundle\Response\RoutesResponse;
+use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
@@ -26,10 +27,9 @@ use Symfony\Component\Serializer\SerializerInterface;
  *
  * @author Benjamin Dulau <benjamin.dulau@anonymation.com>
  */
+#[AsCommand('fos:js-routing:dump', 'Dumps exposed routes to the filesystem')]
 class DumpCommand extends Command
 {
-    protected static $defaultName = 'fos:js-routing:dump';
-
     public function __construct(private ExposedRoutesExtractorInterface $extractor, private SerializerInterface $serializer, private string $projectDir, private ?string $requestContextBaseUrl = null)
     {
         parent::__construct();

--- a/Command/RouterDebugExposedCommand.php
+++ b/Command/RouterDebugExposedCommand.php
@@ -15,6 +15,7 @@ namespace FOS\JsRoutingBundle\Command;
 
 use FOS\JsRoutingBundle\Extractor\ExposedRoutesExtractorInterface;
 use Symfony\Bundle\FrameworkBundle\Console\Helper\DescriptorHelper;
+use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
@@ -29,10 +30,9 @@ use Symfony\Component\Routing\RouterInterface;
  *
  * @author      William DURAND <william.durand1@gmail.com>
  */
+#[AsCommand('fos:js-routing:debug', 'Displays currently exposed routes for an application')]
 class RouterDebugExposedCommand extends Command
 {
-    protected static $defaultName = 'fos:js-routing:debug';
-
     public function __construct(private ExposedRoutesExtractorInterface $extractor, private RouterInterface $router)
     {
         parent::__construct();

--- a/Serializer/Denormalizer/RouteCollectionDenormalizer.php
+++ b/Serializer/Denormalizer/RouteCollectionDenormalizer.php
@@ -45,7 +45,7 @@ class RouteCollectionDenormalizer implements DenormalizerInterface
     /**
      * {@inheritDoc}
      */
-    public function supportsDenormalization(mixed $data, string $type, string $format = null): bool
+    public function supportsDenormalization(mixed $data, string $type, string $format = null, array $context = []): bool
     {
         if (!is_array($data)) {
             return false;

--- a/Serializer/Normalizer/RouteCollectionNormalizer.php
+++ b/Serializer/Normalizer/RouteCollectionNormalizer.php
@@ -47,7 +47,7 @@ class RouteCollectionNormalizer implements NormalizerInterface
     /**
      * {@inheritDoc}
      */
-    public function supportsNormalization(mixed $data, string $format = null): bool
+    public function supportsNormalization(mixed $data, string $format = null, array $context = []): bool
     {
         return $data instanceof RouteCollection;
     }

--- a/Serializer/Normalizer/RoutesResponseNormalizer.php
+++ b/Serializer/Normalizer/RoutesResponseNormalizer.php
@@ -40,7 +40,7 @@ class RoutesResponseNormalizer implements NormalizerInterface
     /**
      * {@inheritDoc}
      */
-    public function supportsNormalization(mixed $data, string $format = null): bool
+    public function supportsNormalization(mixed $data, string $format = null, array $context = []): bool
     {
         return $data instanceof RoutesResponse;
     }


### PR DESCRIPTION
Fixes all symfony 6.1 deprecations:

- Relying on the static property "$defaultName" for setting a command name is deprecated. Add the "Symfony\Component\Console\Attribute\AsCommand" attribute
- NormalizerInterface::supportsNormalization() method will require a new "array $context" argument, not defining it is deprecated.

Tested with lowest and highest dependencies,
Using attributes is safe, as the repository requires PHP8 ans Symfony5.4 as minimum
https://symfony.com/blog/new-in-symfony-5-3-lazy-command-description

