### PR TITLE
Add gitattributes file to ignore tests folder/files

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,4 @@
+.* export-ignore
+Tests export-ignore
+phpunit export-ignore
+phpunit.xml.dist export-ignore

--- a/Resources/js/.gitattributes
+++ b/Resources/js/.gitattributes
@@ -1,0 +1,3 @@
+router.test.js export-ignore
+router_test.html export-ignore
+run_jsunit.js export-ignore


### PR DESCRIPTION
Hi @tobias-93,

I noticed when installing this lib that the test folder is downloaded too.
This PR fix this by declaring files/folder which is not needed when installing the lib.