### PR TITLE
fix Symfony 6.3 deprecation: add getSupportedTypes()

### DIFF
--- a/.github/workflows/code_checks.yaml
+++ b/.github/workflows/code_checks.yaml
@@ -63,6 +63,7 @@ jobs:
       - name: Require Symfony version
         if: matrix.symfony != '*'
         run: |
+          composer global config --no-plugins allow-plugins.symfony/flex true
           composer global require --no-interaction --no-progress symfony/flex:^1.11
           composer config extra.symfony.require ${{ matrix.symfony }}
 

--- a/Serializer/Denormalizer/RouteCollectionDenormalizer.php
+++ b/Serializer/Denormalizer/RouteCollectionDenormalizer.php
@@ -65,4 +65,9 @@ class RouteCollectionDenormalizer implements DenormalizerInterface
 
         return true;
     }
+
+    public function getSupportedTypes(?string $format): array
+    {
+        return ['*' => false];
+    }
 }

--- a/Serializer/Normalizer/RouteCollectionNormalizer.php
+++ b/Serializer/Normalizer/RouteCollectionNormalizer.php
@@ -51,4 +51,9 @@ class RouteCollectionNormalizer implements NormalizerInterface
     {
         return $data instanceof RouteCollection;
     }
+
+    public function getSupportedTypes(?string $format): array
+    {
+        return [RouteCollection::class => true];
+    }
 }

--- a/Serializer/Normalizer/RoutesResponseNormalizer.php
+++ b/Serializer/Normalizer/RoutesResponseNormalizer.php
@@ -44,4 +44,9 @@ class RoutesResponseNormalizer implements NormalizerInterface
     {
         return $data instanceof RoutesResponse;
     }
+
+    public function getSupportedTypes(?string $format): array
+    {
+        return [RoutesResponse::class => true];
+    }
 }


### PR DESCRIPTION
Fixes https://github.com/FriendsOfSymfony/FOSJsRoutingBundle/issues/459