### PR TITLE
Skip registering compile hooks

### DIFF
--- a/Resources/doc/usage.rst
+++ b/Resources/doc/usage.rst
@@ -34,6 +34,22 @@ If you are using webpack and Encore to package your assets you can use the webpa
 
 Then use it simply by importing ``import Routing from 'fos-router';`` in your js or ts code
 
+The plugin hooks into the webpack `build` and `watch` process and triggers the `fos:js-routing:dump` command automatically, 
+once routes have been changed.
+
+To avoid that, e.g. when building the frontend on a machine or docker image/layer, where no PHP is present, you can configure the 
+plugin to use a static dumped `routes.json` and suppress automatic recompilation of the file, by passing some options to the plugin:
+
+.. code-block:: js
+    
+    const FosRouting = require('fos-router/webpack/FosRouting');
+    //...
+    Encore
+        .addPlugin(new FosRouting(
+            { target: './assets/js/routes.json' }, // <- path to dumped routes.json 
+            false // <- set false to suppress automatic recompilation of the file
+            )
+        )
 
 Alternatively you can use the dump command
 and export your routes to json, this command will create a json file into the ``public/js`` folder:

--- a/Resources/webpack/FosRouting.js
+++ b/Resources/webpack/FosRouting.js
@@ -18,11 +18,10 @@ class FosRouting {
         locale: '',
         prettyPrint: false,
         domain: [],
-        php: 'php',
-        skipCompile: false
+        php: 'php'
     };
 
-    constructor(options = {}) {
+    constructor(options = {}, registerCompileHooks = true) {
         this.options = Object.assign({target: 'var/cache/fosRoutes.json'}, this.default, options, {format: 'json'});
         this.finalTarget = path.resolve(process.cwd(), this.options.target);
         this.options.target = path.resolve(process.cwd(), this.options.target.replace(/\.json$/, '.tmp.json'));
@@ -30,7 +29,7 @@ class FosRouting {
         if (this.options.target === this.finalTarget) {
             this.options.target += '.tmp';
         }
-        this.compile = false === this.options.skipCompile;
+        this.registerCompileHooks = registerCompileHooks;
     }
 
     // Values don't need to be escaped because node already does that
@@ -84,7 +83,7 @@ class FosRouting {
             callback();
         };
         
-        if (this.compile) {
+        if (this.registerCompileHooks === true) {
             compiler.hooks.beforeRun.tapAsync('RouteDump', compile);
             compiler.hooks.watchRun.tapAsync('RouteDump_Watch', (comp, callback) => {
                 if (!comp.modifiedFiles || !comp.modifiedFiles.has(this.finalTarget)) {

--- a/Resources/webpack/FosRouting.js
+++ b/Resources/webpack/FosRouting.js
@@ -19,6 +19,7 @@ class FosRouting {
         prettyPrint: false,
         domain: [],
         php: 'php',
+        skipCompile: false
     };
 
     constructor(options = {}) {
@@ -29,6 +30,7 @@ class FosRouting {
         if (this.options.target === this.finalTarget) {
             this.options.target += '.tmp';
         }
+        this.compile = false === this.options.skipCompile;
     }
 
     // Values don't need to be escaped because node already does that
@@ -81,14 +83,17 @@ class FosRouting {
             }
             callback();
         };
-        compiler.hooks.beforeRun.tapAsync('RouteDump', compile);
-        compiler.hooks.watchRun.tapAsync('RouteDump_Watch', (comp, callback) => {
-            if (!comp.modifiedFiles || !comp.modifiedFiles.has(this.finalTarget)) {
-                compile(comp, callback);
-            } else {
-                callback();
-            }
-        });
+        
+        if (this.compile) {
+            compiler.hooks.beforeRun.tapAsync('RouteDump', compile);
+            compiler.hooks.watchRun.tapAsync('RouteDump_Watch', (comp, callback) => {
+                if (!comp.modifiedFiles || !comp.modifiedFiles.has(this.finalTarget)) {
+                    compile(comp, callback);
+                } else {
+                    callback();
+                }
+            });
+        }
 
         new InjectPlugin(() => {
             return 'import Routing from "fos-router";' +


### PR DESCRIPTION
I'm deploying my application via Docker and do Docker multi-stage build (builder-pattern) to build my frontend stuff. This looks a little bit like this:

Excerpt:

```Dockerfile
FROM composer AS composer

# install composer packages

FROM php AS php

COPY --from=composer --chown=root:www-data /app/vendor /app/vendor
COPY --chown=root:www-data . /app

RUN set -eux; \
    php bin/console assets:install; \
    php bin/console fos:js-routing:dump --format json --target assets/fos_js_routes.json;

# [...] configure php base layer

FROM node:16-alpine AS node

COPY package.json yarn.lock webpack.config.js postcss.config.js .babelrc /build/
COPY assets /build/assets
COPY public /build/public
COPY --from=php /app/public/bundles /build/public/bundles
COPY --from=php /app/assets/fos_js_routes.json /build/assets/fos_js_routes.json
COPY --from=php /app/vendor/friendsofsymfony/jsrouting-bundle /build/vendor/friendsofsymfony/jsrouting-bundle

RUN 
    set -eux; \
    yarn --pure-lockfile;  \
    yarn build;

# [...] more frontend stuff...

FROM php AS prod

# Copy frontend files.
COPY --from=node --chown=root:www-data /build/public/build /app/public/build

# [...] finalize the image
```

This way I avoid having composer and node in my runtime image.

Today I wanted to try the FosRouting webpack plugin and noticed, that tries to build the `fos_js_routes.json` during webpack build/watch, wich is pretty convenient, but didn't fit into my build process, since I don't have PHP available during `yarn build`.

So I decided to add an optional parameter to the FoRouting plugin, to disable registering the compile hooks, so the plugin uses the existing, statically dumped `fos_js_routes.json` during runtime.

```js
// webpack.config.js

Encore
        .addPlugin(new FosRouting(
            { target: './assets/fos_js_routes.json' }, // <- path to dumped routes.json 
            false // <- set false to suppress automatic recompilation of the file
            )
        )
```
