### PR TITLE
fix: remove webpack-inject-plugin dependency

### DIFF
--- a/Resources/package.json
+++ b/Resources/package.json
@@ -34,8 +34,8 @@
     "google-closure-library": "^20220104.0.0",
     "gulp": "^4.0.2",
     "gulp-rename": "^2.0.0",
-    "gulp-uglify": "^3.0.2",
     "gulp-typescript": "^6.0.0-alpha.1",
+    "gulp-uglify": "^3.0.2",
     "gulp-wrap": "^0.15.0",
     "jasmine": "^4.0.2",
     "tsd": "^0.19.1",
@@ -47,8 +47,5 @@
     "test": "npm run build && npm run test:types && phantomjs js/run_jsunit.js js/router_test.html",
     "test:types": "tsd",
     "prepublish": "npm run build"
-  },
-  "dependencies": {
-    "webpack-inject-plugin": "^1.5.5"
   }
 }

--- a/Resources/webpack/FosRouting.js
+++ b/Resources/webpack/FosRouting.js
@@ -4,8 +4,7 @@
 const fs = require('fs');
 const path = require('path');
 const util = require('util');
-
-const InjectPlugin = require('webpack-inject-plugin').default;
+const webpack = require("webpack");
 
 const execFile = util.promisify(require('child_process').execFile);
 const readFile = util.promisify(fs.readFile);
@@ -90,11 +89,17 @@ class FosRouting {
             }
         });
 
-        new InjectPlugin(() => {
-            return 'import Routing from "fos-router";' +
-                'import routes from '+JSON.stringify(this.finalTarget)+';' +
-                'Routing.setRoutingData(routes);';
-        }).apply(compiler);
+        new webpack.BannerPlugin({
+            entryOnly: true,
+            include: this.finalTarget ? this.finalTarget + ".js" : /\.js$/,
+            raw: true,
+            banner:
+              'import Routing from "fos-router";' +
+              "import routes from " +
+              JSON.stringify(this.finalTarget) +
+              ";" +
+              "Routing.setRoutingData(routes);",
+          }).apply(compiler);
     }
 }
 


### PR DESCRIPTION
An attempt to replace the dependency on `webpack-inject-plugin` with the Webpack `BannerPlugin` instead.

All tests pass, it seems to work in my local project that uses it. Apologies if I've missed something here or not done something I was supposed to. I am doing this because my company has a requirement for libraries to not have critical security issues.

As mentioned in https://github.com/FriendsOfSymfony/FOSJsRoutingBundle/issues/454