### PR TITLE
Ignore session in stateless requests

### DIFF
--- a/Controller/Controller.php
+++ b/Controller/Controller.php
@@ -45,9 +45,9 @@ class Controller
 
     public function indexAction(Request $request, $_format): Response
     {
-        $session = $request->hasSession() ? $request->getSession() : null;
-
-        if ($request->hasPreviousSession() && $session->getFlashBag() instanceof AutoExpireFlashBag) {
+        if (!$request->attributes->getBoolean('_stateless') && $request->hasSession()
+            && ($session = $request->getSession())->isStarted() && $session->getFlashBag() instanceof AutoExpireFlashBag
+        ) {
             // keep current flashes for one more request if using AutoExpireFlashBag
             $session->getFlashBag()->setAll($session->getFlashBag()->peekAll());
         }


### PR DESCRIPTION
Changed handling of `AutoExpireFlashBag` to same code used in toolbarAction from symfony 6.3 WebProfilerBundle/Controller/ProfilerController.php (see https://github.com/symfony/symfony/pull/50218).

Fixes #467