### PR TITLE
Define RoutesResponse as a Service

### DIFF
--- a/Resources/config/controllers.xml
+++ b/Resources/config/controllers.xml
@@ -7,6 +7,7 @@
     </parameters>
     <services>
         <service id="fos_js_routing.controller" class="%fos_js_routing.controller.class%" public="true">
+            <argument type="service" id="fos_js_routing.routes_response" />
             <argument type="service" id="fos_js_routing.serializer" />
             <argument type="service" id="fos_js_routing.extractor" />
             <argument>%fos_js_routing.cache_control%</argument>

--- a/Resources/config/services.xml
+++ b/Resources/config/services.xml
@@ -5,6 +5,7 @@
 
     <parameters>
         <parameter key="fos_js_routing.extractor.class">FOS\JsRoutingBundle\Extractor\ExposedRoutesExtractor</parameter>
+        <parameter key="fos_js_routing.routes_response.class">FOS\JsRoutingBundle\Response\RoutesResponse</parameter>
     </parameters>
 
     <services>
@@ -14,8 +15,9 @@
             <argument>%kernel.cache_dir%</argument>
             <argument>%kernel.bundles%</argument>
         </service>
-
+        <service id="fos_js_routing.routes_response" class="%fos_js_routing.routes_response.class%" public="true" />
         <service id="fos_js_routing.dump_command" class="FOS\JsRoutingBundle\Command\DumpCommand">
+            <argument type="service" id="fos_js_routing.routes_response" />
             <argument type="service" id="fos_js_routing.extractor" />
             <argument type="service" id="fos_js_routing.serializer" />
             <argument>%kernel.project_dir%</argument>

--- a/Response/RoutesResponse.php
+++ b/Response/RoutesResponse.php
@@ -17,24 +17,25 @@ use Symfony\Component\Routing\RouteCollection;
 
 class RoutesResponse
 {
-    private $routes;
+    protected $routes;
 
-    public function __construct(private string $baseUrl, RouteCollection $routes = null,
-                                private ?string $prefix = null, private ?string $host = null,
-                                private ?string $port = null, private ?string $scheme = null,
-                                private ?string $locale = null, private array $domains = [])
-    {
+    public function __construct(
+        protected ?string $baseUrl = null,
+        RouteCollection $routes = null,
+        protected ?string $prefix = null,
+        protected ?string $host = null,
+        protected ?string $port = null,
+        protected ?string $scheme = null,
+        protected ?string $locale = null,
+        protected array $domains = [],
+    ) {
         $this->routes = $routes ?: new RouteCollection();
-    }
-
-    public function getBaseUrl(): string
-    {
-        return $this->baseUrl;
     }
 
     public function getRoutes(): array
     {
         $exposedRoutes = [];
+
         foreach ($this->routes->all() as $name => $route) {
             if (!$route->hasOption('expose')) {
                 $domain = 'default';
@@ -74,9 +75,29 @@ class RoutesResponse
         return $exposedRoutes;
     }
 
+    public function setRoutes(RouteCollection $routes): void
+    {
+        $this->routes = $routes;
+    }
+
+    public function getBaseUrl(): string
+    {
+        return $this->baseUrl;
+    }
+
+    public function setBaseUrl(string $baseUrl): void
+    {
+        $this->baseUrl = $baseUrl;
+    }
+
     public function getPrefix(): ?string
     {
         return $this->prefix;
+    }
+
+    public function setPrefix(?string $prefix): void
+    {
+        $this->prefix = $prefix;
     }
 
     public function getHost(): ?string
@@ -84,9 +105,19 @@ class RoutesResponse
         return $this->host;
     }
 
+    public function setHost(?string $host): void
+    {
+        $this->host = $host;
+    }
+
     public function getPort(): ?string
     {
         return $this->port;
+    }
+
+    public function setPort(?string $port): void
+    {
+        $this->port = $port;
     }
 
     public function getScheme(): ?string
@@ -94,8 +125,28 @@ class RoutesResponse
         return $this->scheme;
     }
 
+    public function setScheme(?string $scheme): void
+    {
+        $this->scheme = $scheme;
+    }
+
     public function getLocale(): ?string
     {
         return $this->locale;
+    }
+
+    public function setLocale(?string $locale): void
+    {
+        $this->locale = $locale;
+    }
+
+    public function getDomains(): array
+    {
+        return $this->domains;
+    }
+
+    public function setDomains(array $domains): void
+    {
+        $this->domains = $domains;
     }
 }

--- a/Tests/Command/DumpCommandTest.php
+++ b/Tests/Command/DumpCommandTest.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace FOS\JsRoutingBundle\Tests\Command;
 
 use FOS\JsRoutingBundle\Command\DumpCommand;
+use FOS\JsRoutingBundle\Response\RoutesResponse;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Console\Tester\CommandTester;
 use Symfony\Component\Serializer\SerializerInterface;
@@ -22,12 +23,17 @@ use FOS\JsRoutingBundle\Extractor\ExposedRoutesExtractor;
 
 class DumpCommandTest extends TestCase
 {
+    protected RoutesResponse $routesResponse;
     protected $extractor;
     protected $router;
     private $serializer;
 
     public function setUp(): void
     {
+        $this->routesResponse = $this->getMockBuilder(RoutesResponse::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
         $this->extractor = $this->getMockBuilder(ExposedRoutesExtractor::class)
             ->disableOriginalConstructor()
             ->getMock();
@@ -47,7 +53,12 @@ class DumpCommandTest extends TestCase
             ->method('serialize')
             ->will($this->returnValue('{"base_url":"","routes":{"literal":{"tokens":[["text","\/homepage"]],"defaults":[],"requirements":[],"hosttokens":[]},"blog":{"tokens":[["variable","\/","[^\/]++","slug"],["text","\/blog-post"]],"defaults":[],"requirements":[],"hosttokens":[["text","localhost"]]}},"prefix":"","host":"","scheme":""}'));
 
-        $command = new DumpCommand($this->extractor, $this->serializer, '/root/dir');
+        $command = new DumpCommand(
+            $this->routesResponse,
+            $this->extractor,
+            $this->serializer,
+            '/root/dir',
+        );
 
         $tester = new CommandTester($command);
         $tester->execute(['--target' => '/tmp/dump-command-test']);
@@ -64,7 +75,12 @@ class DumpCommandTest extends TestCase
             ->method('serialize')
             ->will($this->returnValue('{"base_url":"","routes":{"literal":{"tokens":[["text","\/homepage"]],"defaults":[],"requirements":[],"hosttokens":[]},"blog":{"tokens":[["variable","\/","[^\/]++","slug"],["text","\/blog-post"]],"defaults":[],"requirements":[],"hosttokens":[["text","localhost"]]}},"prefix":"","host":"","scheme":""}'));
 
-        $command = new DumpCommand($this->extractor, $this->serializer, '/root/dir');
+        $command = new DumpCommand(
+            $this->routesResponse,
+            $this->extractor,
+            $this->serializer,
+            '/root/dir',
+        );
 
         $tester = new CommandTester($command);
         $tester->execute([
@@ -86,7 +102,12 @@ class DumpCommandTest extends TestCase
             ->method('serialize')
             ->will($this->returnValue($json));
 
-        $command = new DumpCommand($this->extractor, $this->serializer, '/root/dir');
+        $command = new DumpCommand(
+            $this->routesResponse,
+            $this->extractor,
+            $this->serializer,
+            '/root/dir',
+        );
 
         $tester = new CommandTester($command);
         $tester->execute([
@@ -104,7 +125,13 @@ class DumpCommandTest extends TestCase
     {
         $this->expectException(\RuntimeException::class);
         $this->expectExceptionMessage('Unable to create directory /root/dir/public/js');
-        $command = new DumpCommand($this->extractor, $this->serializer, '/root/dir');
+
+        $command = new DumpCommand(
+            $this->routesResponse,
+            $this->extractor,
+            $this->serializer,
+            '/root/dir',
+        );
 
         $tester = new CommandTester($command);
         $tester->execute([]);
@@ -118,7 +145,12 @@ class DumpCommandTest extends TestCase
             ->method('serialize')
             ->will($this->returnValue('{"base_url":"","routes":{"literal":{"tokens":[["text","\/homepage"]],"defaults":[],"requirements":[],"hosttokens":[]},"blog":{"tokens":[["variable","\/","[^\/]++","slug"],["text","\/blog-post"]],"defaults":[],"requirements":[],"hosttokens":[["text","localhost"]]}},"prefix":"","host":"","scheme":""}'));
 
-        $command = new DumpCommand($this->extractor, $this->serializer, '/root/dir');
+        $command = new DumpCommand(
+            $this->routesResponse,
+            $this->extractor,
+            $this->serializer,
+            '/root/dir',
+        );
 
         $tester = new CommandTester($command);
         $tester->execute(['--target' => '/tmp']);


### PR DESCRIPTION
Define `Response\RoutesResponse` as a Service allows to override and [decorate](https://symfony.com/doc/current/service_container/service_decoration.html) it, to modify the returned routes for the specific needs of its web app.

It allows then to modify the getRoutes() function with a Decorator for example:

```
<?php

namespace App\Decorator;

use FOS\JsRoutingBundle\Response\RoutesResponse;
use Symfony\Component\DependencyInjection\Attribute\AsDecorator;

#[AsDecorator(decorates: 'fos_js_routing.routes_response')]
class RoutesResponseDecorator extends RoutesResponse
{
    public function getRoutes(): array
    {
        [...]
    }
```