### PR TITLE
Fix TypeScript error when verbatimModuleSyntax is enabled

### DIFF
--- a/Resources/ts/router.test-d.ts
+++ b/Resources/ts/router.test-d.ts
@@ -1,6 +1,6 @@
 import { expectType } from 'tsd';
-import { RoutesMap } from '../js/router';
-import { Route, Router, Routing } from './router';
+import type { RoutesMap } from '../js/router';
+import { Route, Router, type Routing } from './router';
 import routes from './routes.json';
 
 expectType<Router>(Router.getInstance());

--- a/Resources/ts/router.test-d.ts
+++ b/Resources/ts/router.test-d.ts
@@ -1,6 +1,6 @@
 import { expectType } from 'tsd';
 import type { RoutesMap } from '../js/router';
-import { Route, Router, type Routing } from './router';
+import { type Route, Router, Routing } from './router';
 import routes from './routes.json';
 
 expectType<Router>(Router.getInstance());


### PR DESCRIPTION
When `verbatimModuleSyntax` is enabled in TypeScript when building your application two Type errors would pop up. 

```console 
TS1484: 'RoutesMap' is a type and must be imported using a type-only import when 'verbatimModuleSyntax' is enabled.
 
TS1484: 'Route' is a type and must be imported using a type-only import when 'verbatimModuleSyntax' is enabled.
```