### PR TITLE
Make sure the command is copy pastable by removing $

### DIFF
--- a/Resources/doc/installation.rst
+++ b/Resources/doc/installation.rst
@@ -9,7 +9,7 @@ following command to download the latest stable version of this bundle:
 
 .. code-block:: bash
 
-    $ composer require friendsofsymfony/jsrouting-bundle
+    composer require friendsofsymfony/jsrouting-bundle
 
 This command requires you to have Composer installed globally, as explained
 in the `installation chapter`_ of the Composer documentation.


### PR DESCRIPTION
I saw more commands prefixed with `$` but this make it not copy pastable as you will get `$ x` and you have to remove that key. I suggest removing all `$` prefixes.