### PR TITLE
fix: DI Extension deprecated since Symfony 7.1

### DIFF
--- a/DependencyInjection/FOSJsRoutingExtension.php
+++ b/DependencyInjection/FOSJsRoutingExtension.php
@@ -17,8 +17,8 @@ use Symfony\Component\Config\Definition\Processor;
 use Symfony\Component\Config\FileLocator;
 use Symfony\Component\DependencyInjection\Alias;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Extension\Extension;
 use Symfony\Component\DependencyInjection\Loader\XmlFileLoader;
-use Symfony\Component\HttpKernel\DependencyInjection\Extension;
 
 /**
  * @author      William DURAND <william.durand1@gmail.com>


### PR DESCRIPTION
The "Symfony\Component\HttpKernel\DependencyInjection\Extension" class is considered internal since Symfony 7.1, to be deprecated in 8.1; use Symfony\Component\DependencyInjection\Extension\Extension instead. It may change without further notice. You should not use it from "FOS\JsRoutingBundle\DependencyInjection\FOSJsRoutingExtension".

Symfony PR: https://github.com/symfony/symfony/pull/53801