### PR TITLE
Fix PHP 8.4 deprecation notices

### DIFF
--- a/Extractor/ExposedRoutesExtractor.php
+++ b/Extractor/ExposedRoutesExtractor.php
@@ -143,7 +143,7 @@ class ExposedRoutesExtractor implements ExposedRoutesExtractorInterface
     /**
      * {@inheritDoc}
      */
-    public function getCachePath(string $locale = null): string
+    public function getCachePath(?string $locale = null): string
     {
         $cachePath = $this->cacheDir.DIRECTORY_SEPARATOR.'fosJsRouting';
         if (!file_exists($cachePath)) {

--- a/Response/RoutesResponse.php
+++ b/Response/RoutesResponse.php
@@ -21,7 +21,7 @@ class RoutesResponse
 
     public function __construct(
         protected ?string $baseUrl = null,
-        RouteCollection $routes = null,
+        ?RouteCollection $routes = null,
         protected ?string $prefix = null,
         protected ?string $host = null,
         protected ?string $port = null,

--- a/Serializer/Denormalizer/RouteCollectionDenormalizer.php
+++ b/Serializer/Denormalizer/RouteCollectionDenormalizer.php
@@ -22,7 +22,7 @@ class RouteCollectionDenormalizer implements DenormalizerInterface
     /**
      * {@inheritDoc}
      */
-    public function denormalize(mixed $data, string $type, string $format = null, array $context = []): RouteCollection
+    public function denormalize(mixed $data, string $type, ?string $format = null, array $context = []): RouteCollection
     {
         $collection = new RouteCollection();
 
@@ -45,7 +45,7 @@ class RouteCollectionDenormalizer implements DenormalizerInterface
     /**
      * {@inheritDoc}
      */
-    public function supportsDenormalization(mixed $data, string $type, string $format = null, array $context = []): bool
+    public function supportsDenormalization(mixed $data, string $type, ?string $format = null, array $context = []): bool
     {
         if (!is_array($data)) {
             return false;

--- a/Serializer/Normalizer/RouteCollectionNormalizer.php
+++ b/Serializer/Normalizer/RouteCollectionNormalizer.php
@@ -24,7 +24,7 @@ class RouteCollectionNormalizer implements NormalizerInterface
     /**
      * {@inheritDoc}
      */
-    public function normalize(mixed $object, string $format = null, array $context = []): array
+    public function normalize(mixed $object, ?string $format = null, array $context = []): array
     {
         $collection = [];
 
@@ -47,7 +47,7 @@ class RouteCollectionNormalizer implements NormalizerInterface
     /**
      * {@inheritDoc}
      */
-    public function supportsNormalization(mixed $data, string $format = null, array $context = []): bool
+    public function supportsNormalization(mixed $data, ?string $format = null, array $context = []): bool
     {
         return $data instanceof RouteCollection;
     }

--- a/Serializer/Normalizer/RoutesResponseNormalizer.php
+++ b/Serializer/Normalizer/RoutesResponseNormalizer.php
@@ -24,7 +24,7 @@ class RoutesResponseNormalizer implements NormalizerInterface
     /**
      * {@inheritDoc}
      */
-    public function normalize(mixed $object, string $format = null, array $context = []): array
+    public function normalize(mixed $object, ?string $format = null, array $context = []): array
     {
         return [
             'base_url' => $object->getBaseUrl(),
@@ -40,7 +40,7 @@ class RoutesResponseNormalizer implements NormalizerInterface
     /**
      * {@inheritDoc}
      */
-    public function supportsNormalization(mixed $data, string $format = null, array $context = []): bool
+    public function supportsNormalization(mixed $data, ?string $format = null, array $context = []): bool
     {
         return $data instanceof RoutesResponse;
     }

--- a/Tests/Controller/ControllerTest.php
+++ b/Tests/Controller/ControllerTest.php
@@ -243,7 +243,7 @@ class ControllerTest extends TestCase
         $this->assertEquals('{"base_url":"","routes":{"homepage":{"tokens":[["text","\/"]],"defaults":[],"requirements":[],"hosttokens":[],"methods":[],"schemes":[]},"admin_index":{"tokens":[["text","\/admin"]],"defaults":[],"requirements":[],"hosttokens":[],"methods":[],"schemes":[]},"admin_pages":{"tokens":[["text","\/admin\/path"]],"defaults":[],"requirements":[],"hosttokens":[],"methods":[],"schemes":[]},"blog_index":{"tokens":[["text","\/blog"]],"defaults":[],"requirements":[],"hosttokens":[["text","localhost"]],"methods":[],"schemes":[]},"blog_post":{"tokens":[["variable","\/","[^\/]++","slug"],["text","\/blog"]],"defaults":[],"requirements":[],"hosttokens":[["text","localhost"]],"methods":[],"schemes":[]}},"prefix":"","host":"","port":null,"scheme":"","locale":"en"}', $response->getContent());
     }
 
-    private function getExtractor(RouteCollection $exposedRoutes = null, $baseUrl = '')
+    private function getExtractor(?RouteCollection $exposedRoutes = null, $baseUrl = '')
     {
         if (null === $exposedRoutes) {
             $exposedRoutes = new RouteCollection();


### PR DESCRIPTION
- Fixes PHP 8.4 deprecation notices.
- See https://php.watch/versions/8.4/implicitly-marking-parameter-type-nullable-deprecated

Is it possible to do a patch release after merge? :-) Thanks!