### PR TITLE
[webpack-plugin] fix(#465): Exclude php from command arguments

### DIFF
--- a/Resources/webpack/FosRouting.js
+++ b/Resources/webpack/FosRouting.js
@@ -20,6 +20,7 @@ class FosRouting {
         domain: [],
         php: 'php'
     };
+    nonArgumentOptions = ['php'];
 
     constructor(options = {}, registerCompileHooks = true) {
         this.options = Object.assign({target: 'var/cache/fosRoutes.json'}, this.default, options, {format: 'json'});
@@ -54,6 +55,10 @@ class FosRouting {
         }
         const compile = async (comp, callback) => {
             const args = Object.keys(this.options).reduce((pass, key) => {
+                if (this.nonArgumentOptions.includes(key)) {
+                    return pass;
+                }
+
                 const val = this.options[key];
                 if (val !== this.default[key]) {
                     if (Array.isArray(val)) {
@@ -82,7 +87,7 @@ class FosRouting {
             }
             callback();
         };
-        
+
         if (this.registerCompileHooks === true) {
             compiler.hooks.beforeRun.tapAsync('RouteDump', compile);
             compiler.hooks.watchRun.tapAsync('RouteDump_Watch', (comp, callback) => {


### PR DESCRIPTION
This PR solves issue #465 with excluding `php` from the console command arguments in the Webpack plugin class.

The current version adds all options defined in the class as arguments to the command. I added an array of non-argument options to exclude these from the argument list (currently `php` only).