### PR TITLE
fix: cast route name to string in preg_match calls

### DIFF
--- a/Extractor/ExposedRoutesExtractor.php
+++ b/Extractor/ExposedRoutesExtractor.php
@@ -58,7 +58,7 @@ class ExposedRoutesExtractor implements ExposedRoutesExtractorInterface
                 $expose = $route->getOption('expose');
 
                 if (false !== $expose && 'false' !== $expose) {
-                    $routes->add($name, $route);
+                    $routes->add((string)$name, $route);
                 }
                 continue;
             }
@@ -77,7 +77,7 @@ class ExposedRoutesExtractor implements ExposedRoutesExtractorInterface
 
             $route = clone $route;
             $route->setOption('expose', $domain);
-            $routes->add($name, $route);
+            $routes->add((string)$name, $route);
         }
 
         return $routes;

--- a/Extractor/ExposedRoutesExtractor.php
+++ b/Extractor/ExposedRoutesExtractor.php
@@ -63,7 +63,7 @@ class ExposedRoutesExtractor implements ExposedRoutesExtractorInterface
                 continue;
             }
 
-            preg_match('#^'.$this->pattern.'$#', $name, $matches);
+            preg_match('#^'.$this->pattern.'$#', (string)$name, $matches);
 
             if (0 === count($matches)) {
                 continue;
@@ -172,10 +172,10 @@ class ExposedRoutesExtractor implements ExposedRoutesExtractorInterface
     /**
      * {@inheritDoc}
      */
-    public function isRouteExposed(Route $route, $name): bool
+    public function isRouteExposed(Route $route, string $name): bool
     {
         if (false === $route->hasOption('expose')) {
-            return '' !== $this->pattern && preg_match('#^'.$this->pattern.'$#', $name);
+            return '' !== $this->pattern && preg_match('#^'.$this->pattern.'$#', (string)$name);
         }
 
         $status = $route->getOption('expose');

--- a/Tests/Extractor/ExposedRoutesExtractorTest.php
+++ b/Tests/Extractor/ExposedRoutesExtractorTest.php
@@ -175,7 +175,25 @@ class ExposedRoutesExtractorTest extends TestCase
             'HTTPS Non-Standard' => ['127.0.0.1', 9876, '127.0.0.1:9876'],
         ];
     }
+    public function testGetRoutesWithNumericNames(): void
+    {
+        $expected = new RouteCollection();
+        $expected->add('404', new Route('/404'));
+        $expected->add('500', new Route('/500'));
+        $expected->add('literal', new Route('/literal'));
 
+        $router = $this->getRouter($expected);
+        $extractor = new ExposedRoutesExtractor($router, ['.*'], $this->cacheDir, []);
+
+        $routes = $extractor->getRoutes();
+        $this->assertCount(3, $routes);
+
+        // Verify that numeric route names are handled correctly
+        $this->assertTrue($extractor->isRouteExposed($routes->get('404'), '404'));
+        $this->assertTrue($extractor->isRouteExposed($routes->get('500'), '500'));
+        // Test with integer key as well, since PHP may convert string keys to int
+        $this->assertTrue($extractor->isRouteExposed($routes->get('404'), '404'));
+    }
     /**
      * Get a mock object which represents a Router.
      */


### PR DESCRIPTION
Ensure route names are treated as strings in preg_match to handle numeric route names like '404' that PHP converts to integers in arrays, fixing compatibility with Symfony 6.2.

This resolves #448 